### PR TITLE
fix(backend): 恢复 dev 编译 + distillation 路由租户隔离 + 测试构建遗留

### DIFF
--- a/backend/src/axum_routers/mod.rs
+++ b/backend/src/axum_routers/mod.rs
@@ -2,9 +2,6 @@
 //!
 //! This module provides Axum-based API routes to replace Salvo.
 
-pub mod agent;
-pub mod auth;
-pub mod demo;
 pub mod distributed;
 
 use std::time::Instant;
@@ -96,7 +93,17 @@ mod tests {
 
         let output = get_exporter().generate_prometheus_output();
         assert!(output.contains("memory_requests_total{endpoint=\"/\",status=\"200\"}"));
-        assert!(output.contains("memory_request_duration_seconds_count 1"));
+        // The exporter is a process-global singleton shared across the whole
+        // test binary, so the duration count is not guaranteed to be exactly 1
+        // here — only to have grown by at least the one request this test made.
+        // Assert a positive count rather than the brittle exact-`1` form.
+        let duration_count = output
+            .lines()
+            .find(|l| l.starts_with("memory_request_duration_seconds_count"))
+            .and_then(|l| l.rsplit(' ').next())
+            .and_then(|v| v.parse::<u64>().ok())
+            .expect("memory_request_duration_seconds_count line present");
+        assert!(duration_count >= 1, "duration count should be >= 1, got {duration_count}");
         assert!(!output.contains("request_id=unbounded-value"));
     }
 }

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -107,6 +107,22 @@ pub fn init() {
         config.db.backend = crate::config::DatabaseBackend::Sqlite;
     }
 
+    // APP_RECONCILIATION_INTERVAL_SECONDS — figment would map this to
+    // `reconciliation.interval.seconds` instead of `reconciliation.interval_seconds`,
+    // so spell it out explicitly.
+    if let Ok(val) = std::env::var("APP_RECONCILIATION_INTERVAL_SECONDS") {
+        if let Ok(secs) = val.parse::<u64>() {
+            config.reconciliation.interval_seconds = secs;
+        }
+    }
+
+    // APP_RECONCILIATION_MODE — explicit to avoid figment nested-key ambiguity.
+    if let Ok(mode) = std::env::var("APP_RECONCILIATION_MODE") {
+        if !mode.is_empty() {
+            config.reconciliation.mode = mode;
+        }
+    }
+
     if crate::config::CONFIG.set(config).is_err() {
         tracing::debug!("[config] Configuration already initialized; retaining existing value");
     }
@@ -161,6 +177,58 @@ pub struct MemoryTransferConfig {
     pub session_time_threshold: i32,
 }
 
+/// Vector reconciliation scanner configuration.
+///
+/// The scanner periodically compares PostgreSQL `knowledge_entries` against
+/// Qdrant points to detect four classes of drift: missing (DB entry with no
+/// Qdrant point), orphan (Qdrant point with no DB entry), tenant mismatch, and
+/// content-hash mismatch.  In `dry_run` mode the scan is **read-only** — it
+/// records drift rows, logs counts and updates Prometheus gauges but never
+/// enqueues outbox events.  In `repair` mode it additionally enqueues outbox
+/// events to fix the drift.
+///
+/// The scanner is enabled by default because leaving it disabled preserves the
+/// existing bug where vector drift is never detected.  `repair` mode enqueues
+/// bulk Qdrant writes and must be explicitly opted into — it should never be
+/// the default in committed configuration.
+///
+/// `mode` must be one of the values accepted by
+/// [`crate::db::vector_reconciliation::ReconciliationMode::parse`] — the
+/// scanner validates it once at startup and falls back to `dry_run` with a
+/// `WARN` if it does not parse, so a typo degrades to read-only rather than
+/// failing every scan.
+#[derive(Deserialize, Clone, Debug)]
+pub struct ReconciliationConfig {
+    /// Enable the periodic reconciliation scanner. Defaults to true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Seconds between reconciliation scans. Default 3600 (1 hour).
+    /// Values below the scanner's floor are raised, with a `WARN`.
+    #[serde(default = "default_reconciliation_interval")]
+    pub interval_seconds: u64,
+    /// Scan mode: `"dry_run"` (read-only) or `"repair"` (enqueues outbox writes).
+    #[serde(default = "default_reconciliation_mode")]
+    pub mode: String,
+}
+
+impl Default for ReconciliationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_seconds: default_reconciliation_interval(),
+            mode: default_reconciliation_mode(),
+        }
+    }
+}
+
+fn default_reconciliation_interval() -> u64 {
+    3600
+}
+
+fn default_reconciliation_mode() -> String {
+    "dry_run".to_string()
+}
+
 #[derive(Deserialize, Clone, Debug)]
 pub struct ServerConfig {
     #[serde(default = "default_listen_addr")]
@@ -189,6 +257,13 @@ pub struct ServerConfig {
     pub recall: RecallConfig,
     #[serde(default)]
     pub skills: SkillsConfig,
+    #[serde(default)]
+    pub reconciliation: ReconciliationConfig,
+    /// Trusted reverse-proxy IPs whose `X-Forwarded-For` header is honoured by
+    /// the rate limiter. Empty (the default) → XFF is never trusted and the
+    /// direct peer IP is always used. Restored from 4eeecaa (lost in the merge).
+    #[serde(default)]
+    pub trusted_proxies: Vec<std::net::IpAddr>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -273,6 +273,53 @@ pub struct JwtConfig {
     #[serde(default)]
     pub disabled: bool,
 }
+
+/// Known placeholder JWT secrets shipped in examples/templates. Booting with
+/// one while auth is enabled is a deterministic misconfiguration.
+const INSECURE_JWT_SECRETS: &[&str] = &[
+    "REPLACE_WITH_STRONG_SECRET_OR_USE_APP_JWT_SECRET",
+    "change-me-in-production-32chars",
+    "change-me",
+    "changeme",
+    "secret",
+    "your-secret-key",
+];
+
+/// Minimum acceptable JWT secret length (bytes) when auth is enabled.
+const MIN_JWT_SECRET_LEN: usize = 32;
+
+/// Validate that the JWT signing secret is safe for a production startup.
+///
+/// Returns `Err` (so the caller can fail-fast) when authentication is enabled
+/// but the secret is a known placeholder or shorter than `MIN_JWT_SECRET_LEN`.
+/// When `jwt.disabled` is set (explicit local/dev mode) validation is skipped.
+pub fn validate_jwt_security(config: &ServerConfig) -> Result<(), String> {
+    check_jwt_secret(config.jwt.disabled, &config.jwt.secret)
+}
+
+fn check_jwt_secret(disabled: bool, secret: &str) -> Result<(), String> {
+    if disabled {
+        return Ok(());
+    }
+    let secret = secret.trim();
+    if INSECURE_JWT_SECRETS.contains(&secret) {
+        return Err(
+            "Insecure JWT secret: the configured value is a known placeholder. Set a strong \
+             random secret via the APP_JWT_SECRET environment variable (e.g. `openssl rand -hex 32`), \
+             or set jwt.disabled=true for local loopback dev only."
+                .to_string(),
+        );
+    }
+    if secret.len() < MIN_JWT_SECRET_LEN {
+        return Err(format!(
+            "Insecure JWT secret: must be at least {MIN_JWT_SECRET_LEN} characters (got {}). Set a \
+             strong random secret via the APP_JWT_SECRET environment variable (e.g. \
+             `openssl rand -hex 32`), or set jwt.disabled=true for local loopback dev only.",
+            secret.len()
+        ));
+    }
+    Ok(())
+}
 #[derive(Deserialize, Clone, Debug)]
 pub struct TlsConfig {
     pub cert: String,

--- a/backend/src/db/distillation.rs
+++ b/backend/src/db/distillation.rs
@@ -113,16 +113,19 @@ impl DistillationRepository {
         })
     }
 
-    pub async fn get_atom(id: &str) -> Result<Option<L1Atom>, AppError> {
+    pub async fn get_atom(id: &str, tenant_id: &TenantId) -> Result<Option<L1Atom>, AppError> {
         let pool = pool();
-        sqlx::query_as::<_, L1Atom>("SELECT * FROM distillation_atoms WHERE id = $1")
-            .bind(id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| {
-                error!("Failed to get atom: {}", e);
-                AppError::Internal(format!("Database error: {}", e))
-            })
+        sqlx::query_as::<_, L1Atom>(
+            "SELECT * FROM distillation_atoms WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(id)
+        .bind(tenant_id.as_str())
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to get atom: {}", e);
+            AppError::Internal(format!("Database error: {}", e))
+        })
     }
 
     pub async fn deactivate_atom(id: &str, superseded_by: &str) -> Result<(), AppError> {
@@ -251,16 +254,19 @@ impl DistillationRepository {
         })
     }
 
-    pub async fn get_scene(id: &str) -> Result<Option<L2Scene>, AppError> {
+    pub async fn get_scene(id: &str, tenant_id: &TenantId) -> Result<Option<L2Scene>, AppError> {
         let pool = pool();
-        sqlx::query_as::<_, L2Scene>("SELECT * FROM distillation_scenes WHERE id = $1")
-            .bind(id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| {
-                error!("Failed to get scene: {}", e);
-                AppError::Internal(format!("Database error: {}", e))
-            })
+        sqlx::query_as::<_, L2Scene>(
+            "SELECT * FROM distillation_scenes WHERE id = $1 AND tenant_id = $2",
+        )
+        .bind(id)
+        .bind(tenant_id.as_str())
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to get scene: {}", e);
+            AppError::Internal(format!("Database error: {}", e))
+        })
     }
 
     // === L3 Persona operations ===

--- a/backend/src/routers/data_io.rs
+++ b/backend/src/routers/data_io.rs
@@ -137,7 +137,7 @@ async fn export_as_json(
     match layer {
         "mm" | "all" => {
             let response =
-                MMRepository::list_entries(None, Some(limit), Some(0), Some(tenant_id.as_str()))
+                MMRepository::list_entries(None, Some(limit), Some(0), tenant_id.as_str())
                     .await?;
             data["mm"] = serde_json::json!({
                 "entries": response.entries,
@@ -219,7 +219,7 @@ async fn export_as_markdown(
     if layer == "mm" || layer == "all" {
         content.push_str("## Multimodal Memory (MM)\n\n");
         let response =
-            MMRepository::list_entries(None, Some(limit), Some(0), Some(tenant_id.as_str()))
+            MMRepository::list_entries(None, Some(limit), Some(0), tenant_id.as_str())
                 .await?;
         for entry in response.entries {
             content.push_str(&format!(

--- a/backend/src/routers/demo.rs
+++ b/backend/src/routers/demo.rs
@@ -5,8 +5,11 @@ use serde::Deserialize;
 
 use crate::AppResult;
 
+// Tolerate unknown query params (e.g. `?request_id=…`): a public endpoint must
+// not 400 on extra params. Keeping this strict would break the cardinality-leak
+// guard in `axum_routers::tests::records_completed_requests_with_the_matched_path`,
+// which sends a high-cardinality `request_id` to assert it never reaches labels.
 #[derive(Debug, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
 pub struct HelloQuery {
     pub name: Option<String>,
 }

--- a/backend/src/routers/distillation.rs
+++ b/backend/src/routers/distillation.rs
@@ -8,7 +8,7 @@ use tracing::{error, info};
 use crate::db::distillation::DistillationRepository;
 use crate::models::distillation::DistillationJobType;
 use crate::services::distillation::DistillationService;
-use crate::tenant::get_default_tenant;
+use crate::tenant::RequestTenantContext;
 
 #[derive(Debug, Deserialize)]
 pub struct TriggerRequest {
@@ -81,15 +81,17 @@ fn error_response(msg: &str) -> impl IntoResponse {
     )
 }
 
-pub async fn trigger_distillation(Json(req): Json<TriggerRequest>) -> impl IntoResponse {
+pub async fn trigger_distillation(
+    tenant_ctx: RequestTenantContext,
+    Json(req): Json<TriggerRequest>,
+) -> impl IntoResponse {
     info!(
-        "Manual distillation trigger: user={}, session={}",
-        req.user_id, req.session_id
+        "Manual distillation trigger: tenant={}, user={}, session={}",
+        tenant_ctx.tenant_id, req.user_id, req.session_id
     );
 
-    let tenant_id = get_default_tenant();
     match DistillationService::enqueue_job(
-        &tenant_id,
+        &tenant_ctx.tenant_id,
         &req.user_id,
         &req.agent_id,
         &req.session_id,
@@ -105,10 +107,12 @@ pub async fn trigger_distillation(Json(req): Json<TriggerRequest>) -> impl IntoR
     }
 }
 
-pub async fn list_atoms(Query(params): Query<ListAtomsQuery>) -> impl IntoResponse {
-    let tenant_id = get_default_tenant();
+pub async fn list_atoms(
+    tenant_ctx: RequestTenantContext,
+    Query(params): Query<ListAtomsQuery>,
+) -> impl IntoResponse {
     match DistillationRepository::list_atoms(
-        &tenant_id,
+        &tenant_ctx.tenant_id,
         &params.user_id,
         &params.agent_id,
         params.atom_type.as_deref(),
@@ -126,8 +130,11 @@ pub async fn list_atoms(Query(params): Query<ListAtomsQuery>) -> impl IntoRespon
     }
 }
 
-pub async fn get_atom(Path(id): Path<String>) -> impl IntoResponse {
-    match DistillationRepository::get_atom(&id).await {
+pub async fn get_atom(
+    tenant_ctx: RequestTenantContext,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match DistillationRepository::get_atom(&id, &tenant_ctx.tenant_id).await {
         Ok(Some(atom)) => ApiResponse::ok(atom).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -141,9 +148,11 @@ pub async fn get_atom(Path(id): Path<String>) -> impl IntoResponse {
     }
 }
 
-pub async fn list_scenes(Query(params): Query<ListScenesQuery>) -> impl IntoResponse {
-    let tenant_id = get_default_tenant();
-    match DistillationRepository::list_scenes(&tenant_id, &params.user_id, &params.agent_id).await {
+pub async fn list_scenes(
+    tenant_ctx: RequestTenantContext,
+    Query(params): Query<ListScenesQuery>,
+) -> impl IntoResponse {
+    match DistillationRepository::list_scenes(&tenant_ctx.tenant_id, &params.user_id, &params.agent_id).await {
         Ok(scenes) => ApiResponse::ok(scenes).into_response(),
         Err(e) => {
             error!("Failed to list scenes: {}", e);
@@ -152,8 +161,11 @@ pub async fn list_scenes(Query(params): Query<ListScenesQuery>) -> impl IntoResp
     }
 }
 
-pub async fn get_scene(Path(id): Path<String>) -> impl IntoResponse {
-    match DistillationRepository::get_scene(&id).await {
+pub async fn get_scene(
+    tenant_ctx: RequestTenantContext,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match DistillationRepository::get_scene(&id, &tenant_ctx.tenant_id).await {
         Ok(Some(scene)) => ApiResponse::ok(scene).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -167,9 +179,11 @@ pub async fn get_scene(Path(id): Path<String>) -> impl IntoResponse {
     }
 }
 
-pub async fn get_persona(Query(params): Query<GetPersonaQuery>) -> impl IntoResponse {
-    let tenant_id = get_default_tenant();
-    match DistillationRepository::get_persona(&tenant_id, &params.user_id, &params.agent_id).await {
+pub async fn get_persona(
+    tenant_ctx: RequestTenantContext,
+    Query(params): Query<GetPersonaQuery>,
+) -> impl IntoResponse {
+    match DistillationRepository::get_persona(&tenant_ctx.tenant_id, &params.user_id, &params.agent_id).await {
         Ok(Some(persona)) => ApiResponse::ok(persona).into_response(),
         Ok(None) => (
             StatusCode::NOT_FOUND,
@@ -183,10 +197,12 @@ pub async fn get_persona(Query(params): Query<GetPersonaQuery>) -> impl IntoResp
     }
 }
 
-pub async fn list_jobs(Query(params): Query<ListJobsQuery>) -> impl IntoResponse {
-    let tenant_id = get_default_tenant();
+pub async fn list_jobs(
+    tenant_ctx: RequestTenantContext,
+    Query(params): Query<ListJobsQuery>,
+) -> impl IntoResponse {
     match DistillationRepository::list_jobs(
-        &tenant_id,
+        &tenant_ctx.tenant_id,
         params.status.as_deref(),
         params.limit,
         params.offset,

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -45,7 +45,9 @@ mod workflows;
 
 use std::sync::Arc;
 
+#[cfg(feature = "a2a")]
 use crate::a2a::a2a_router;
+#[cfg(feature = "a2a")]
 use crate::a2a::handler::A2AHandler;
 use crate::layers::procedural_layer::ProceduralMemoryLayer;
 use crate::{config, hoops, services::prometheus_exporter};
@@ -57,7 +59,8 @@ struct Assets;
 pub fn root() -> Router {
     let _ = &config::get().jwt;
     let auth_layer = middleware::from_fn(hoops::jwt::auth_middleware);
-    let rate_limit_state = hoops::rate_limit_state(100, 60);
+    let trusted_proxies = config::get().trusted_proxies.clone();
+    let rate_limit_state = hoops::rate_limit_state(100, 60, trusted_proxies.clone());
     let memory_rate_limit =
         middleware::from_fn_with_state(rate_limit_state, hoops::rate_limit_middleware);
 
@@ -421,10 +424,15 @@ pub fn root() -> Router {
         )
         .route_layer(auth_layer);
 
-    // A2A Protocol support
-    let a2a_base_url = format!("http://{}/api", config::get().listen_addr);
-    let a2a_handler = Arc::new(A2AHandler::new());
-    let a2a_routes = a2a_router(a2a_base_url, a2a_handler);
+    // A2A Protocol support — only mounted when the `a2a` feature is enabled.
+    // It is OFF by default (its git deps fetch during resolution); CI builds it
+    // in a dedicated job. See `lib.rs` and `Cargo.toml` [features].
+    #[cfg(feature = "a2a")]
+    let a2a_routes = {
+        let a2a_base_url = format!("http://{}/api", config::get().listen_addr);
+        let a2a_handler = Arc::new(A2AHandler::new());
+        a2a_router(a2a_base_url, a2a_handler)
+    };
 
     let api_router = Router::new()
         .route("/login", post(auth::post_login))
@@ -435,8 +443,9 @@ pub fn root() -> Router {
         .merge(protected_api_router)
         .merge(mcp::router())
         .merge(data_io::router())
-        .nest("/v1/tracing", tracing::router())
-        .merge(a2a_routes);
+        .nest("/v1/tracing", tracing::router());
+    #[cfg(feature = "a2a")]
+    let api_router = api_router.merge(a2a_routes);
 
     Router::new()
         .route("/", get(demo::hello))

--- a/backend/src/services/llm.rs
+++ b/backend/src/services/llm.rs
@@ -7,12 +7,33 @@ use tracing::{error, info, instrument, warn};
 
 use crate::config;
 
-/// LLM 服务，用于调用本地 LLM（Ollama）进行内容总结和结构化提取
+/// LLM 摘要调用的错误分类。
+///
+/// 让调用方能区分「后端真的不可达」（可安全降级）与「后端可达但返回错误状态或
+/// 无法解析的内容」（必须暴露，而不是伪装成一次「降级」写入）。这是 D-e 降级方案
+/// 的关键：只有 `Unavailable` / `Upstream` 允许降级，`Malformed` 属于真实故障。
+#[derive(Debug, thiserror::Error)]
+pub enum LlmError {
+    /// 后端完全无法连通（连接被拒、DNS 失败、超时）。即「Ollama 不可达」场景。
+    #[error("LLM backend unavailable: {0}")]
+    Unavailable(String),
+    /// 后端可达，但返回了非 2xx 的 HTTP 状态。
+    #[error("LLM backend returned error status {status}")]
+    Upstream { status: u16 },
+    /// 后端有响应，但响应体（外层信封或内容 JSON）无法解析为可用结果。
+    /// 表示真实 bug 或模型/prompt 问题——不是短暂的服务不可用。
+    #[error("LLM response could not be parsed: {0}")]
+    Malformed(String),
+}
+
+/// LLM 服务，用于调用本地 LLM（Ollama）或 OpenAI 兼容 API 进行内容总结和结构化提取
 pub struct LLMService {
     client: Client,
     base_url: String,
     model: String,
     timeout: Duration,
+    api_type: String,
+    api_key: Option<String>,
 }
 
 impl LLMService {
@@ -27,8 +48,8 @@ impl LLMService {
             .map_err(|e| anyhow::anyhow!("Failed to create HTTP client: {}", e))?;
 
         info!(
-            "LLM service initialized: base_url={}, model={}",
-            config.llm.base_url, config.llm.model
+            "LLM service initialized: base_url={}, model={}, api_type={}",
+            config.llm.base_url, config.llm.model, config.llm.api_type
         );
 
         Ok(Self {
@@ -36,6 +57,8 @@ impl LLMService {
             base_url: config.llm.base_url.clone(),
             model: config.llm.model.clone(),
             timeout,
+            api_type: config.llm.api_type.clone(),
+            api_key: config.llm.api_key.clone(),
         })
     }
 
@@ -107,7 +130,7 @@ impl LLMService {
                     "Response text (first 500 chars): {}",
                     &response_text.chars().take(500).collect::<String>()
                 );
-                anyhow::anyhow!("Failed to parse LLM response: {}", e)
+                anyhow::Error::new(LlmError::Malformed(e.to_string()))
             })?;
 
         // 确保 summary 不为空（如果 LLM 没有提供，使用默认值）
@@ -146,13 +169,24 @@ impl LLMService {
         Ok(summary)
     }
 
-    /// Public wrapper for call_llm, allowing external services to invoke the LLM directly.
+    /// Public wrapper for `call_llm`, letting external services (e.g. the
+    /// distillation atom extractor) invoke the LLM directly without
+    /// duplicating the Ollama/OpenAI-compatible dispatch.
     pub async fn call_llm_public(&self, prompt: &str) -> Result<String> {
         self.call_llm(prompt).await
     }
 
+    /// 调用 LLM API（支持 Ollama 和 OpenAI 兼容格式）
+    pub async fn call_llm(&self, prompt: &str) -> Result<String> {
+        if self.api_type == "openai" {
+            self.call_openai_compatible(prompt).await
+        } else {
+            self.call_ollama(prompt).await
+        }
+    }
+
     /// 调用 Ollama API
-    async fn call_llm(&self, prompt: &str) -> Result<String> {
+    async fn call_ollama(&self, prompt: &str) -> Result<String> {
         let url = format!("{}/api/generate", self.base_url);
 
         let request_body = json!({
@@ -169,7 +203,7 @@ impl LLMService {
             .await
             .map_err(|e| {
                 error!("Failed to send request to Ollama: {}", e);
-                anyhow::anyhow!("Failed to call LLM: {}", e)
+                anyhow::Error::new(LlmError::Unavailable(e.to_string()))
             })?;
 
         if !response.status().is_success() {
@@ -179,15 +213,62 @@ impl LLMService {
                 "Ollama API returned error: status={}, body={}",
                 status, error_text
             );
-            return Err(anyhow::anyhow!("Ollama API error: status={}", status));
+            return Err(anyhow::Error::new(LlmError::Upstream {
+                status: status.as_u16(),
+            }));
         }
 
         let ollama_response: OllamaResponse = response.json().await.map_err(|e| {
             error!("Failed to parse Ollama response: {}", e);
-            anyhow::anyhow!("Failed to parse response: {}", e)
+            anyhow::Error::new(LlmError::Malformed(e.to_string()))
         })?;
 
         Ok(ollama_response.response)
+    }
+
+    /// 调用 OpenAI 兼容 API（含 DashScope）
+    async fn call_openai_compatible(&self, prompt: &str) -> Result<String> {
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let request_body = json!({
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": false
+        });
+
+        let mut request = self.client.post(&url).json(&request_body);
+
+        if let Some(ref key) = self.api_key {
+            request = request.header("Authorization", format!("Bearer {}", key));
+        }
+
+        let response = request.send().await.map_err(|e| {
+            error!("Failed to send request to OpenAI-compatible API: {}", e);
+            anyhow::Error::new(LlmError::Unavailable(e.to_string()))
+        })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            error!(
+                "OpenAI-compatible API returned error: status={}, body={}",
+                status, error_text
+            );
+            return Err(anyhow::Error::new(LlmError::Upstream {
+                status: status.as_u16(),
+            }));
+        }
+
+        let openai_response: OpenAIChatResponse = response.json().await.map_err(|e| {
+            error!("Failed to parse OpenAI-compatible response: {}", e);
+            anyhow::Error::new(LlmError::Malformed(e.to_string()))
+        })?;
+
+        Ok(openai_response
+            .choices
+            .first()
+            .map(|c| c.message.content.clone())
+            .unwrap_or_default())
     }
 }
 
@@ -195,6 +276,22 @@ impl LLMService {
 #[derive(Debug, Deserialize)]
 struct OllamaResponse {
     response: String,
+}
+
+/// OpenAI 兼容 API 响应（含 DashScope）
+#[derive(Debug, Deserialize)]
+struct OpenAIChatResponse {
+    choices: Vec<OpenAIChatChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIChatChoice {
+    message: OpenAIChatMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIChatMessage {
+    content: String,
 }
 
 /// 实体类型枚举

--- a/backend/tests/a2a_integration.rs
+++ b/backend/tests/a2a_integration.rs
@@ -1,4 +1,9 @@
+#![cfg(feature = "a2a")]
 //! A2A Protocol Integration Tests
+//!
+//! Compiled only with `--features a2a` (the dedicated `backend-a2a` CI job);
+//! `backend::a2a` is `#[cfg(feature = "a2a")]`, so this test does not exist in
+//! the default feature set.
 
 use axum::{
     body::{self, Body},
@@ -22,7 +27,7 @@ fn authenticated_request() -> axum::http::request::Builder {
 
 fn authenticated_request_for(tenant_id: &str) -> axum::http::request::Builder {
     backend::config::init();
-    let (token, _) = backend::hoops::jwt::get_token(tenant_id).expect("generate A2A test JWT");
+    let (token, _) = backend::hoops::jwt::get_token(tenant_id, None).expect("generate A2A test JWT");
     Request::builder().header("authorization", format!("Bearer {token}"))
 }
 

--- a/backend/tests/data_io_security.rs
+++ b/backend/tests/data_io_security.rs
@@ -15,7 +15,7 @@ fn ensure_config() {
 
 fn auth_header(user_id: &str) -> String {
     ensure_config();
-    let (token, _) = backend::hoops::jwt::get_token(user_id).expect("generate test JWT");
+    let (token, _) = backend::hoops::jwt::get_token(user_id, None).expect("generate test JWT");
     format!("Bearer {token}")
 }
 

--- a/backend/tests/distillation_security.rs
+++ b/backend/tests/distillation_security.rs
@@ -1,0 +1,85 @@
+//! Security boundary tests for the `/api/v1/distillation/*` routes.
+//!
+//! These routes were landed in 952a899 reading the shared default tenant
+//! (`get_default_tenant()`) instead of the caller's authenticated tenant — a
+//! cross-tenant data leak (same class as the P0s fixed in 77daf57). They now
+//! scope every read/trigger by `RequestTenantContext::tenant_id`.
+//!
+//! These tests guard the auth boundary only (JWT required). Verifying the
+//! tenant scoping end-to-end needs the `distillation_*` tables present in the
+//! test DB with two tenants' rows — that is a test-infra follow-up, not
+//! covered here.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+static CONFIG_INIT: std::sync::Once = std::sync::Once::new();
+
+fn ensure_config() {
+    CONFIG_INIT.call_once(|| {
+        backend::config::init();
+    });
+}
+
+async fn response_json(response: axum::response::Response) -> (StatusCode, Value) {
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let json = serde_json::from_slice(&body).expect("parse JSON response");
+    (status, json)
+}
+
+#[tokio::test]
+async fn list_atoms_requires_a_jwt_before_accessing_storage() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/distillation/atoms?user_id=u&agent_id=a")
+                .body(Body::empty())
+                .expect("build list_atoms request"),
+        )
+        .await
+        .expect("serve list_atoms request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}
+
+#[tokio::test]
+async fn trigger_distillation_requires_a_jwt_before_enqueuing() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/distillation/trigger")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({"user_id":"u","agent_id":"a","session_id":"s"}).to_string(),
+                ))
+                .expect("build trigger request"),
+        )
+        .await
+        .expect("serve trigger request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}


### PR DESCRIPTION
## 目标

dev 自 `952a899` 起不可编译（13 errors，CI 未覆盖直推 dev），且 952a899 新落的 distillation 路由有跨租户数据泄漏。本 PR 一次性修两类问题：

1. 恢复 dev 编译（坏合并丢失的类型 / 门控 / 调用方失同步）
2. 修复 distillation 路由的跨租户泄漏（按认证态 tenant 隔离）

## 变更（3 个提交）

### `3821947` 恢复 dev 编译
- `services/llm.rs`: 回退到 4eeecaa（恢复 `LlmError` 枚举 + OpenAI 兼容）+ 补 `call_llm_public`（atom_extractor 在用），恢复 memory_storage 的 D-e 降级契约
- `config/mod.rs`: 插回 `ReconciliationConfig`（结构体+Default+helpers+字段+env 映射）与 `trusted_proxies` 字段
- `routers/mod.rs`: a2a 装配加 `#[cfg(feature="a2a")]`，恢复 `trusted_proxies` 派生与 `rate_limit_state` 第 3 参
- `axum_routers/mod.rs`: 删 3 行死 `pub mod`；把脆弱的 prometheus `count==1` 断言改为计数≥1 的测试隔离安全形式
- `routers/data_io.rs`: `list_entries` 第 4 参已是 &str，去掉多余 `Some(...)`
- `routers/demo.rs`: 去 `deny_unknown_fields`，让高基数 query 的 cardinality-leak 测试可达

### `9470030` distillation 路由租户隔离
- `routers/distillation.rs`: 7 个 handler 提取 `RequestTenantContext`，用 `&tenant_ctx.tenant_id` 替换 `get_default_tenant()`（关闭跨租户批量泄漏）；`user_id`/`agent_id` 按仓库 `store_stm` 惯例保留为客户端参数
- `db/distillation.rs`: `get_atom`/`get_scene` 加 tenant 过滤（`WHERE id=$1 AND tenant_id=$2`），避免按 id 越权读
- `tests/distillation_security.rs`: 新增 auth-gate 测试（401）

### `a1453b4` 测试/构建 infra 遗留
- `config/mod.rs`: 按 4eeecaa 恢复 `validate_jwt_security` + `check_jwt_secret` + 两个常量（main.rs 启动 fail-fast 用）
- `tests/data_io_security.rs` / `a2a_integration.rs`: `get_token(x)` → `get_token(x, None)`（C-3 后 get_token 已 2 参）
- `tests/a2a_integration.rs`: 顶部加 `#![cfg(feature="a2a")]`，仅在 a2a job 编译

## 风险

- **llm.rs 回退到 4eeecaa**：恢复了 952a899 简化掉的 OpenAI 兼容支持。这是 CLAUDE.md 既定支持（"Ollama 或任何 OpenAI 兼容端点"），4eeecaa 时通过 443 测试，回归风险低。
- **distillation user_id 仍为客户端参数**：本次只关跨租户泄漏，未做跨 user 隔离（沿用 `store_stm` 惯例）。若需更严格的 per-user ACL，是单独的 RBAC 决策。
- **a2a 路由门控**：a2a 默认关闭（Cargo.toml 既定），本 PR 让其装配与之对齐；a2a CI job 仍用 `--features a2a` 验证。
- 公共 API 契约未变（distillation 路由 path/参数不变，仅内部 tenant 来源改了）。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets              # 0 error
cargo test --lib                        # 415 passed / 0 failed / 3 ignored
cargo test --test distillation_security # 2 passed
cargo test --test data_io_security      # 4 passed
\`\`\`

## 文档影响

- 无 API 契约变化，无需更新 OpenAPI/前端。
- 对应 tracker #94 的 P0 验收"跨租户泄漏率为 0"一环。issue #85（导入占位成功）此前已在 952a899 修复，本 PR 不再重复。

## 未覆盖（follow-up，不在本 PR）

- distillation 子系统仍是 SQLite 岛，未接 PG 主链路（#83）。
- \`AutoRecallService\` 零调用方，召回/注入半边未接线（#84）。
- 无 \`turn_committed\`/\`before_recall\` 生命周期钩子（#84）。
- \`validate_embedding_config\` 启动 fail-fast 被 952a899 连调用一起删，属另一个安全回归，需单独恢复 + 验证启动路径。
- distillation DB 级跨租户回归测试（需 distillation_* 表落测试库）。