### PR TITLE
fix(backend): 显式禁用 Letta stub provider——构建即拒、不再谎报能力 (#87)

### DIFF
--- a/backend/src/providers/letta.rs
+++ b/backend/src/providers/letta.rs
@@ -25,10 +25,15 @@ impl MemoryProvider for LettaProvider {
     }
 
     fn capabilities(&self) -> ProviderCapabilities {
+        // Reserved stub — reports no capabilities so discovery never marks an
+        // unimplemented provider as available (#87). This stub is not reachable
+        // via `create_provider` (which rejects `ProviderType::Letta`); the
+        // all-false report is a defense-in-depth guarantee if it is ever
+        // instantiated directly.
         ProviderCapabilities {
-            supports_vector_search: true,
+            supports_vector_search: false,
             supports_graph: false,
-            supports_metadata_filter: true,
+            supports_metadata_filter: false,
             supports_eviction: false,
             max_entry_size_bytes: None,
         }

--- a/backend/src/providers/mod.rs
+++ b/backend/src/providers/mod.rs
@@ -39,11 +39,69 @@ pub fn validate_path_segment(segment: &str) -> MemoryResult<()> {
     Ok(())
 }
 
-pub fn create_provider(config: &ProviderConfig) -> Box<dyn MemoryProvider> {
+/// Construct the active provider from config.
+///
+/// `ProviderType::Letta` is a reserved, unimplemented stub and is **rejected
+/// here** rather than silently built — selecting it surfaces a clear error
+/// instead of a provider whose every operation returns "not implemented".
+/// This is #87's "显式禁用" path (option 2): the stub stays as a reserved
+/// marker, but it cannot be constructed for production use.
+pub fn create_provider(config: &ProviderConfig) -> MemoryResult<Box<dyn MemoryProvider>> {
     match config.active {
-        ProviderType::Builtin => Box::new(BuiltinProvider::new()),
-        ProviderType::Mem0 => Box::new(Mem0Provider::new(config.mem0.clone().unwrap_or_default())),
-        ProviderType::Zep => Box::new(ZepProvider::new(config.zep.clone().unwrap_or_default())),
-        ProviderType::Letta => Box::new(letta::LettaProvider::new()),
+        ProviderType::Builtin => Ok(Box::new(BuiltinProvider::new())),
+        ProviderType::Mem0 => Ok(Box::new(Mem0Provider::new(
+            config.mem0.clone().unwrap_or_default(),
+        ))),
+        ProviderType::Zep => Ok(Box::new(ZepProvider::new(
+            config.zep.clone().unwrap_or_default(),
+        ))),
+        ProviderType::Letta => Err(MemoryError::InvalidOperation(
+            "Letta provider is reserved but not implemented; select builtin, mem0, or zep"
+                .to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_provider_is_constructible() {
+        let cfg = ProviderConfig::default(); // active = Builtin
+        assert!(create_provider(&cfg).is_ok());
+    }
+
+    #[test]
+    fn mem0_and_zep_providers_are_constructible() {
+        let cfg = ProviderConfig {
+            active: ProviderType::Mem0,
+            ..Default::default()
+        };
+        assert!(create_provider(&cfg).is_ok());
+        let cfg = ProviderConfig {
+            active: ProviderType::Zep,
+            ..Default::default()
+        };
+        assert!(create_provider(&cfg).is_ok());
+    }
+
+    #[test]
+    fn letta_provider_is_rejected_with_a_clear_error() {
+        let cfg = ProviderConfig {
+            active: ProviderType::Letta,
+            ..Default::default()
+        };
+        // `unwrap_err()` would require `Box<dyn MemoryProvider>: Debug`; match
+        // instead to avoid that bound.
+        let err = match create_provider(&cfg) {
+            Err(e) => e,
+            Ok(_) => panic!("Letta provider should be rejected, but create_provider returned Ok"),
+        };
+        assert!(
+            matches!(err, MemoryError::InvalidOperation(_)),
+            "expected InvalidOperation, got {err:?}"
+        );
+        assert!(err.to_string().contains("Letta"));
     }
 }

--- a/backend/src/routers/procedural.rs
+++ b/backend/src/routers/procedural.rs
@@ -255,7 +255,8 @@ pub struct ProviderCapabilitiesDto {
 
 pub async fn provider_health() -> JsonResult<ProviderHealthResponse> {
     let config = ProviderConfig::default();
-    let provider = create_provider(&config);
+    let provider = create_provider(&config)
+        .map_err(|e| crate::error::AppError::Internal(format!("failed to create provider: {e}")))?;
 
     let health = provider
         .health_check()


### PR DESCRIPTION
## 目标

#87 的"显式禁用"路径（option 2）：Letta 是 reserved stub，但 `create_provider` 仍会静默构建它且 `capabilities()` 谎报能力。本 PR 让 Letta **构建即拒**、stub 不再谎报能力。

## 变更

- `providers/mod.rs`: `create_provider` 签名改 `MemoryResult<Box<dyn MemoryProvider>>`，`ProviderType::Letta` 分支返 `Err(InvalidOperation)`（拒绝构建而非静默 stub）；Builtin/Mem0/Zep 保持 `Ok`。+3 单测。
- `providers/letta.rs`: `capabilities()` 全 false——reserved stub 不再谎报 `supports_vector_search`/`supports_metadata_filter`（create_provider 已拒绝构建它，all-false 是纵深防御）。
- `routers/procedural.rs`: `provider_health` 唯一调用点 `map_err` 处理 `Result`（默认 Builtin，实际永不触发 Letta 错误）。

## 设计说明

- `ProviderConfig` 不在 `ServerConfig`、config.toml/.env.example 无 provider 配置 → 无独立"启动校验"入口；拒绝点落在 `create_provider`（构建时），等价于 #87 的"明确错误"。
- `ProviderType::Letta` 枚举变体**保留**（reserved 标记），不删——避免 serde 破坏性变更；只是不可被构建。
- 未走 feature-flag 路径：构建时拒绝已满足"无法被生产配置选中"，且无需引入 feature 机制。

## 风险

- `create_provider` 签名 `Box<dyn>` → `MemoryResult<Box<dyn>>` 是 crate 内 public API 变更，但仅 1 个调用方（`provider_health`），已同步处理；无外部 SDK 使用（grep 确认）。
- 默认配置 `ProviderConfig::default()` 是 Builtin，故 `provider_health` 行为不变。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets    # 0 error
cargo test --lib              # 418 passed / 0 failed / 3 ignored
cargo test --lib providers::   # 含新增 3 个测试
\`\`\`

## 验收对照 (#87)

- [x] 未实现时无法被生产配置选中——`create_provider` 拒绝构建 Letta
- [x] 能力发现不得将未实现 provider 标记为 available——stub `capabilities()` 全 false
- [x] 若实现，CRUD/超时/重试/健康检查契约测试——N/A（本次走禁用路径，不实现）
- [x] 文档准确区分可用/实验性/规划中 provider——`providers/mod.rs` 注释标注 Letta: stub