### PR TITLE
feat(protocol): 接通 WebSocket 实时记忆事件（#86 首期 increment）

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -145,6 +145,11 @@ async fn main() {
     // is observable via crate::db::neo4j_status(), not an optimistic log line.
     crate::db::spawn_neo4j_init(&config.neo4j);
 
+    // Issue #86: WebSocket connection manager singleton — used by the
+    // /api/v1/ws upgrade handler and by memory write/delete event emitters.
+    crate::protocol::websocket::init_ws_manager();
+    tracing::info!("WebSocket connection manager initialized");
+
     tracing::info!("log level: {}", &config.log.filter_level);
 
     tracing::info!("Initializing memory transfer service");

--- a/backend/src/protocol/websocket.rs
+++ b/backend/src/protocol/websocket.rs
@@ -5,7 +5,9 @@
 //! WebSocket upgrade handler (`ws_upgrade_handler`) authenticates during
 //! the HTTP handshake via `hoops::jwt::authenticate()`.
 //!
-//! `send_to_session` remains a placeholder until a real axum WS route is wired.
+//! `send_to_session` returns a truthful subscription check; the primary push
+//! path is `broadcast_event` + per-connection forward filtering. A real axum WS
+//! route is mounted at `/api/v1/ws` (see `routers::mod::root`).
 #![allow(dead_code)]
 
 use crate::hoops::jwt;
@@ -128,7 +130,7 @@ pub struct UnsubscribeRequest {
 }
 
 /// Event types for subscriptions
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EventType {
     MemoryAdded,
@@ -136,6 +138,24 @@ pub enum EventType {
     MemoryDeleted,
     MemoryEvicted,
     LayerFull,
+}
+
+/// Lightweight event payload pushed over WebSocket — avoids carrying the full
+/// kernel `MemoryEntry` (which may hold `Binary`/`GraphData`) over the wire.
+/// `summary` is truncated to ~256 chars so a client can decide whether to
+/// fetch the full entry. `tenant_id` is present on every variant so the
+/// broadcast forward task can filter by tenant without deserializing deeply.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryEventPayload {
+    pub id: String,
+    pub tenant_id: String,
+    pub layer: LayerType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 /// Stored response
@@ -178,15 +198,30 @@ pub struct EventResponse {
     pub data: EventData,
 }
 
-/// Event data
+/// Event data — lightweight variants; every variant carries `tenant_id` so
+/// the broadcast forward task can filter by tenant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum EventData {
-    MemoryAdded(MemoryEntry),
-    MemoryUpdated { id: String, entry: MemoryEntry },
-    MemoryDeleted { id: String },
-    MemoryEvicted { ids: Vec<String> },
-    LayerFull { layer: LayerType, capacity: usize },
+    MemoryAdded(MemoryEventPayload),
+    MemoryUpdated {
+        id: String,
+        payload: MemoryEventPayload,
+    },
+    MemoryDeleted {
+        id: String,
+        layer: LayerType,
+        tenant_id: String,
+    },
+    MemoryEvicted {
+        ids: Vec<String>,
+        tenant_id: String,
+    },
+    LayerFull {
+        layer: LayerType,
+        capacity: usize,
+        tenant_id: String,
+    },
 }
 
 /// Error response
@@ -312,8 +347,10 @@ impl WsConnectionManager {
         }
     }
 
-    /// Broadcast an event to all subscribed connections.
-    pub async fn broadcast_event(&self, event: EventResponse) -> usize {
+    /// Broadcast an event to all subscribed connections. Synchronous and
+    /// non-blocking (`broadcast::Sender::send` never awaits) so callers can
+    /// fire-and-forget it from hot paths (memory write/delete chokepoints).
+    pub fn broadcast_event(&self, event: EventResponse) -> usize {
         self.event_tx.send(event).unwrap_or(0)
     }
 
@@ -322,25 +359,21 @@ impl WsConnectionManager {
         self.connections.read().await.len()
     }
 
-    /// Send event to a specific session (if subscribed).
+    /// Whether a session would receive `event`: the session must exist and
+    /// either have no subscriptions (receive-all default) or be subscribed to
+    /// this event type. NOTE: actual delivery happens via the broadcast
+    /// channel the forward task in `handle_ws_connection` drains — this is a
+    /// truthful query, not a send (the old stub always returned `true`).
     pub async fn send_to_session(&self, session_id: &str, event: EventResponse) -> bool {
         let connections = self.connections.read().await;
-        if let Some(conn) = connections.get(session_id) {
-            // Check if the connection is subscribed to this event type
-            let is_subscribed = conn.subscriptions.iter().any(|sub| {
-                matches!(&event.event_type, EventType::MemoryAdded if matches!(sub.event_type, EventType::MemoryAdded))
-                    || matches!(&event.event_type, EventType::MemoryUpdated if matches!(sub.event_type, EventType::MemoryUpdated))
-                    || matches!(&event.event_type, EventType::MemoryDeleted if matches!(sub.event_type, EventType::MemoryDeleted))
-                    || matches!(&event.event_type, EventType::MemoryEvicted if matches!(sub.event_type, EventType::MemoryEvicted))
-                    || matches!(&event.event_type, EventType::LayerFull if matches!(sub.event_type, EventType::LayerFull))
-            });
-
-            // For simplicity, always return true if session exists
-            // In real implementation, would send via WebSocket
-            true
-        } else {
-            false
-        }
+        let Some(conn) = connections.get(session_id) else {
+            return false;
+        };
+        conn.subscriptions.is_empty()
+            || conn
+                .subscriptions
+                .iter()
+                .any(|sub| sub.event_type == event.event_type)
     }
 
     /// Clean up old sessions (based on timestamp).
@@ -356,6 +389,30 @@ impl WsConnectionManager {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Global singleton — the WS manager is reached both from the axum upgrade
+// handler and from the memory write/delete chokepoints (static service methods
+// with no DI). Mirrors LLM_SERVICE / DATABASE_POOL.
+// ─────────────────────────────────────────────────────────────────────────────
+
+static WS_MANAGER: std::sync::OnceLock<std::sync::Arc<WsConnectionManager>> =
+    std::sync::OnceLock::new();
+
+/// Get the global WebSocket connection manager. Panics if not initialized —
+/// `init_ws_manager()` MUST be called from `main` at startup.
+pub fn ws_manager() -> &'static std::sync::Arc<WsConnectionManager> {
+    WS_MANAGER.get().expect("WS_MANAGER not initialized")
+}
+
+/// Initialize the global WS manager singleton. Call once at startup (main.rs),
+/// before the HTTP server accepts connections.
+pub fn init_ws_manager() {
+    WS_MANAGER
+        .set(std::sync::Arc::new(WsConnectionManager::new()))
+        .ok()
+        .expect("WS_MANAGER already initialized");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Axum WebSocket upgrade handler with handshake auth (ADR-0007, P2 PR-3).
 //
 // Authenticates the HTTP upgrade request via `hoops::jwt::authenticate()`
@@ -364,22 +421,7 @@ impl WsConnectionManager {
 // ─────────────────────────────────────────────────────────────────────────────
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::State as AxumState;
 use axum::response::IntoResponse;
-
-/// Shared state for the WebSocket handler.
-#[derive(Clone)]
-pub struct WsHandlerState {
-    pub manager: std::sync::Arc<WsConnectionManager>,
-}
-
-impl Default for WsHandlerState {
-    fn default() -> Self {
-        Self {
-            manager: std::sync::Arc::new(WsConnectionManager::new()),
-        }
-    }
-}
 
 /// Axum WebSocket upgrade handler.
 ///
@@ -396,7 +438,6 @@ impl Default for WsHandlerState {
 pub async fn ws_upgrade_handler(
     ws: WebSocketUpgrade,
     Extension(tenant_ctx): Extension<crate::tenant::RequestTenantContext>,
-    AxumState(_state): AxumState<WsHandlerState>,
 ) -> impl IntoResponse {
     ws.on_upgrade(move |socket| handle_ws_connection(socket, tenant_ctx))
 }
@@ -405,50 +446,125 @@ async fn handle_ws_connection(
     mut socket: WebSocket,
     tenant_ctx: crate::tenant::RequestTenantContext,
 ) {
-    use crate::services::memory_search::MemorySearchService;
-    use crate::services::memory_storage::MemoryStorageService;
+    let manager = ws_manager();
+    let (session_id, mut broadcast_rx) = manager.create_session(tenant_ctx.clone()).await;
 
-    while let Some(Ok(msg)) = socket.recv().await {
-        let Message::Text(text) = msg else {
-            continue;
-        };
+    // Send the Connected frame so the client knows its session_id.
+    let connected = WsMessage {
+        msg_type: WsMessageType::Connected,
+        request_id: None,
+        payload: WsPayload::Connected(ConnectedResponse {
+            session_id: session_id.clone(),
+            server_version: env!("CARGO_PKG_VERSION").to_string(),
+        }),
+    };
+    if socket
+        .send(Message::Text(
+            serde_json::to_string(&connected).unwrap_or_default().into(),
+        ))
+        .await
+        .is_err()
+    {
+        manager.remove_session(&session_id).await;
+        return;
+    }
 
-        let response = match serde_json::from_str::<WsMessage>(&text) {
-            Ok(ws_msg) => {
-                let result = handle_ws_message(&ws_msg, &tenant_ctx).await;
-                serde_json::json!({
-                    "request_id": ws_msg.request_id,
-                    "success": result.is_ok(),
-                    "result": result.as_ref().ok(),
-                    "error": result.as_ref().err().map(|e| e.to_string()),
-                })
+    // Drive client→server (request/response) and server→client (broadcast
+    // push) concurrently. Either side breaking ends the connection.
+    loop {
+        tokio::select! {
+            // ── Client → Server ──
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        let response = match serde_json::from_str::<WsMessage>(&text) {
+                            Ok(ws_msg) => {
+                                let result = handle_ws_message(
+                                    &ws_msg, &tenant_ctx, &session_id, manager,
+                                ).await;
+                                serde_json::json!({
+                                    "request_id": ws_msg.request_id,
+                                    "success": result.is_ok(),
+                                    "result": result.as_ref().ok(),
+                                    "error": result.as_ref().err().map(|e| e.to_string()),
+                                })
+                            }
+                            Err(e) => serde_json::json!({
+                                "success": false,
+                                "error": format!("invalid message: {e}"),
+                            }),
+                        };
+                        if socket
+                            .send(Message::Text(response.to_string().into()))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Some(Ok(_)) => continue, // non-text frames ignored
+                    Some(Err(_)) | None => break,
+                }
             }
-            Err(e) => {
-                serde_json::json!({
-                    "success": false,
-                    "error": format!("invalid message: {e}"),
-                })
-            }
-        };
 
-        if socket
-            .send(Message::Text(response.to_string().into()))
-            .await
-            .is_err()
-        {
-            break;
+            // ── Server → Client (broadcast push) ──
+            event = broadcast_rx.recv() => {
+                match event {
+                    Ok(event) => {
+                        if should_forward_event(manager, &session_id, &tenant_ctx, &event).await {
+                            let msg = WsMessage {
+                                msg_type: WsMessageType::Event,
+                                request_id: None,
+                                payload: WsPayload::Event(event),
+                            };
+                            if socket
+                                .send(Message::Text(
+                                    serde_json::to_string(&msg).unwrap_or_default().into(),
+                                ))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            session_id = %session_id,
+                            skipped = n,
+                            "WS client lagged, dropping events"
+                        );
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
         }
     }
+
+    manager.remove_session(&session_id).await;
 }
 
 async fn handle_ws_message(
     msg: &WsMessage,
     tenant_ctx: &crate::tenant::RequestTenantContext,
+    session_id: &str,
+    manager: &WsConnectionManager,
 ) -> Result<serde_json::Value, String> {
     use crate::services::memory_search::MemorySearchService;
     use crate::services::memory_storage::MemoryStorageService;
 
     match &msg.payload {
+        WsPayload::Subscribe(req) => {
+            let sub_id = manager
+                .subscribe(session_id, req.event_type.clone())
+                .await
+                .ok_or_else(|| "session not found".to_string())?;
+            Ok(serde_json::json!({ "subscription_id": sub_id, "event_type": req.event_type }))
+        }
+        WsPayload::Unsubscribe(req) => {
+            let ok = manager.unsubscribe(session_id, &req.subscription_id).await;
+            Ok(serde_json::json!({ "unsubscribed": req.subscription_id, "ok": ok }))
+        }
         WsPayload::Search(req) => {
             let query = req.query.as_deref().unwrap_or("");
             let results = MemorySearchService::search_ltm_for_tenant(
@@ -477,6 +593,39 @@ async fn handle_ws_message(
         }
         _ => Err("unsupported operation".to_string()),
     }
+}
+
+/// Whether a broadcast `event` should be forwarded to `session_id`:
+/// tenant must match AND (no subscriptions = receive-all, OR subscribed to
+/// this event type). Slow-consumer / closed-connection handling lives in the
+/// caller's `select!` loop (send-failure breaks the loop).
+async fn should_forward_event(
+    manager: &WsConnectionManager,
+    session_id: &str,
+    tenant_ctx: &crate::tenant::RequestTenantContext,
+    event: &EventResponse,
+) -> bool {
+    // 1. Tenant check — every EventData variant carries tenant_id.
+    let event_tenant: &str = match &event.data {
+        EventData::MemoryAdded(p) => &p.tenant_id,
+        EventData::MemoryUpdated { payload, .. } => &payload.tenant_id,
+        EventData::MemoryDeleted { tenant_id, .. } => tenant_id,
+        EventData::MemoryEvicted { tenant_id, .. } => tenant_id,
+        EventData::LayerFull { tenant_id, .. } => tenant_id,
+    };
+    if event_tenant != tenant_ctx.tenant_id.as_str() {
+        return false;
+    }
+
+    // 2. Subscription check — empty subscriptions = receive all.
+    let Some(conn) = manager.get_connection(session_id).await else {
+        return false;
+    };
+    conn.subscriptions.is_empty()
+        || conn
+            .subscriptions
+            .iter()
+            .any(|sub| sub.event_type == event.event_type)
 }
 
 impl Default for WsConnectionManager {
@@ -567,5 +716,67 @@ mod tests {
 
         manager.remove_session(&session2).await;
         assert_eq!(manager.connection_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn broadcast_delivers_to_subscribed_receiver() {
+        let manager = WsConnectionManager::new();
+        let tenant_ctx = crate::tenant::RequestTenantContext::new("tenant-a");
+        let (_session_id, mut rx) = manager.create_session(tenant_ctx).await;
+
+        let event = EventResponse {
+            event_type: EventType::MemoryAdded,
+            data: EventData::MemoryAdded(MemoryEventPayload {
+                id: "id-1".to_string(),
+                tenant_id: "tenant-a".to_string(),
+                layer: LayerType::Ltm,
+                source_type: None,
+                summary: Some("s".to_string()),
+                metadata: None,
+            }),
+        };
+        // One receiver subscribed → broadcast returns 1 and the receiver gets it.
+        assert_eq!(manager.broadcast_event(event.clone()), 1);
+        let recv = rx.recv().await.unwrap();
+        assert_eq!(recv.event_type, EventType::MemoryAdded);
+    }
+
+    #[tokio::test]
+    async fn should_forward_filters_by_tenant_and_subscription() {
+        let manager = WsConnectionManager::new();
+        let tenant_a = crate::tenant::RequestTenantContext::new("tenant-a");
+        let (session_id, _rx) = manager.create_session(tenant_a.clone()).await;
+
+        let deleted = |tenant: &str| EventResponse {
+            event_type: EventType::MemoryDeleted,
+            data: EventData::MemoryDeleted {
+                id: "id".to_string(),
+                layer: LayerType::Ltm,
+                tenant_id: tenant.to_string(),
+            },
+        };
+        let added = |tenant: &str| EventResponse {
+            event_type: EventType::MemoryAdded,
+            data: EventData::MemoryAdded(MemoryEventPayload {
+                id: "id".to_string(),
+                tenant_id: tenant.to_string(),
+                layer: LayerType::Ltm,
+                source_type: None,
+                summary: None,
+                metadata: None,
+            }),
+        };
+
+        // No subscriptions → receive all (same tenant).
+        assert!(should_forward_event(&manager, &session_id, &tenant_a, &deleted("tenant-a")).await);
+        // Cross-tenant → never forwarded.
+        assert!(!should_forward_event(&manager, &session_id, &tenant_a, &deleted("tenant-b")).await);
+
+        // Subscribe to MemoryDeleted only.
+        manager.subscribe(&session_id, EventType::MemoryDeleted).await;
+        // Matching type + tenant → forwarded.
+        assert!(should_forward_event(&manager, &session_id, &tenant_a, &deleted("tenant-a")).await);
+        // Non-matching type (MemoryAdded) with an active subscription → filtered out.
+        assert!(!should_forward_event(&manager, &session_id, &tenant_a, &added("tenant-a")).await);
     }
 }

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -323,6 +323,7 @@ pub fn root() -> Router {
         .nest("/v1", agent_routes)
         .nest("/v1/workflows", workflow_evidence_routes)
         .nest("/v1/memory", memory_routes)
+        .route("/v1/ws", get(crate::protocol::websocket::ws_upgrade_handler))
         .nest(
             "/kg",
             Router::new()

--- a/backend/src/services/memory_contract.rs
+++ b/backend/src/services/memory_contract.rs
@@ -157,6 +157,24 @@ pub async fn forget_memory(
         }
     };
 
+    // Issue #86: fire-and-forget WS event only when something was actually deleted.
+    if deleted {
+        let layer_type = match layer.as_str() {
+            "stm" => crate::kernel::types::LayerType::Stm,
+            _ => crate::kernel::types::LayerType::Ltm,
+        };
+        let _ = crate::protocol::websocket::ws_manager().broadcast_event(
+            crate::protocol::websocket::EventResponse {
+                event_type: crate::protocol::websocket::EventType::MemoryDeleted,
+                data: crate::protocol::websocket::EventData::MemoryDeleted {
+                    id: req.memory_id.clone(),
+                    layer: layer_type,
+                    tenant_id: tenant_id.as_str().to_string(),
+                },
+            },
+        );
+    }
+
     Ok(MemoryForgetResponse {
         success: true,
         memory_id: req.memory_id,

--- a/backend/src/services/memory_storage.rs
+++ b/backend/src/services/memory_storage.rs
@@ -213,6 +213,29 @@ impl MemoryStorageService {
             "STM stored successfully: session_id={}, message_id={}",
             session_id, message_id
         );
+
+        // Issue #86: fire-and-forget WS event (sync broadcast, near-free with 0 subscribers).
+        let _ = crate::protocol::websocket::ws_manager().broadcast_event(
+            crate::protocol::websocket::EventResponse {
+                event_type: crate::protocol::websocket::EventType::MemoryAdded,
+                data: crate::protocol::websocket::EventData::MemoryAdded(
+                    crate::protocol::websocket::MemoryEventPayload {
+                        id: message_id.clone(),
+                        tenant_id: tenant_id.as_str().to_string(),
+                        layer: crate::kernel::types::LayerType::Stm,
+                        source_type: None,
+                        summary: Some(content.chars().take(256).collect()),
+                        metadata: Some(serde_json::json!({
+                            "sessionId": session_id,
+                            "role": role,
+                            "userId": user_id,
+                            "agentId": agent_id,
+                        })),
+                    },
+                ),
+            },
+        );
+
         Ok((session_id, message_id))
     }
 
@@ -471,6 +494,25 @@ impl MemoryStorageService {
         tokio::task::spawn_blocking(move || {
             crate::services::information_guard::record_write(&write_record);
         });
+
+        // Issue #86: fire-and-forget WS event. `broadcast_event` is synchronous
+        // and near-free with zero subscribers; `metadata` is moved above in both
+        // PG/SQLite branches so it is not reused here.
+        let _ = crate::protocol::websocket::ws_manager().broadcast_event(
+            crate::protocol::websocket::EventResponse {
+                event_type: crate::protocol::websocket::EventType::MemoryAdded,
+                data: crate::protocol::websocket::EventData::MemoryAdded(
+                    crate::protocol::websocket::MemoryEventPayload {
+                        id: entry_id.clone(),
+                        tenant_id: tenant_id.as_str().to_string(),
+                        layer: crate::kernel::types::LayerType::Ltm,
+                        source_type: Some(normalized_source_type.to_string()),
+                        summary: Some(embed_text.chars().take(256).collect()),
+                        metadata: None,
+                    },
+                ),
+            },
+        );
 
         Ok(StoreLtmResult {
             entry_id,


### PR DESCRIPTION
## 目标

#86 首期 increment：`protocol/websocket.rs` 是一整套孤儿模块（已有 `ws_upgrade_handler`/`WsConnectionManager`/`handle_ws_connection` 但没挂路由、不转发广播、`send_to_session` 假成功、无事件源）。本 PR 接线现有脚手架，交付**认证态 WS endpoint + 服务端 push 记忆事件 + 订阅/租户过滤 + 广播背压**。

## 变更

**`protocol/websocket.rs`**（主改）
- 加全局 `WS_MANAGER` 单例 + `ws_manager()`/`init_ws_manager()`（对齐 `LLM_SERVICE`/`DATABASE_POOL` 模式，供 service 层静态方法与 handler 共用）；删 `WsHandlerState`。
- 轻量化 `EventData`：`MemoryAdded(MemoryEntry)` → `MemoryAdded(MemoryEventPayload){id, tenant_id, layer, source_type?, summary?(截256), metadata?}`，每变体带 `tenant_id` 供转发过滤；去掉过重的 kernel `MemoryEntry`。
- `broadcast_event` 改同步（`broadcast::send` 本就非阻塞，0 订阅近免费）。
- `ws_upgrade_handler` 去掉 `State` extractor（用 `ws_manager()`）。
- 重写 `handle_ws_connection`：`create_session` → 发 `Connected` 帧 → `select!` 双分支（client↔server recv + server→client 广播转发，按 tenant+subscription 过滤、`Lagged` warn+continue、`Closed`/send失败 break）→ `remove_session`。
- 加 `should_forward_event`（tenant + subscription 过滤）；扩 `handle_ws_message` 支持 `Subscribe`/`Unsubscribe`；`send_to_session` 改诚实返回（去假成功）。

**`main.rs`**：启动 `init_ws_manager()`。
**`routers/mod.rs`**：`protected_api_router` 加 `.route("/v1/ws", get(ws_upgrade_handler))`（已 `route_layer(auth_layer)`，自动需认证）。
**`services/memory_storage.rs`**：`store_ltm_for_tenant` 与 `store_stm_for_tenant` `Ok` 前发 `MemoryAdded`（LTM/STM 写 chokepoint，覆盖 REST/MCP/A2A/gRPC/ingestion/transfer/batch）。
**`services/memory_contract.rs`**：`forget_memory` `if deleted` 发 `MemoryDeleted`。

## 设计决策

- **全局单例**（非 DI）：`store_ltm_for_tenant` 是静态方法无 DI，代码库既有单例模式（LLM/DATABASE_POOL），对齐之。
- **EventData 轻量化**：现 `MemoryAdded(MemoryEntry)` 携带完整 kernel `MemoryEntry`（可能含 `Binary`/`GraphData`），过重且 chokepoint 处不易构造；`EventData` 当前零调用方，改形态非破坏。
- **背压**：首期用 broadcast cap 1000 + `Lagged` 跳过（慢消费者 lag 被丢弃 + warn）。per-conn 有界 mpsc 列 follow-up。
- **`send_to_session`**：保留作定向投递工具，改诚实返回（session 缺失/未订阅返 false）；主 push 路径是 broadcast+filter。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets  # 0 error
cargo test --lib            # 417 passed / 0 failed / 3 ignored
cargo test --lib protocol::websocket  # 4 tests（含新增 2 个：broadcast 投递 + tenant/订阅过滤）
\`\`\`

手动 smoke（需起 server + 登录拿 JWT cookie）：未认证 upgrade `/api/v1/ws` → 401；带 cookie → 101；连上后 `POST /api/v1/memory/storage/ltm` → 收到 `event_type: memory_added` JSON 帧。

## 验收对照 (#86，首期覆盖项)

- [x] 存在可认证的 WebSocket upgrade endpoint（`/api/v1/ws`，经 `protected_api_router` 的 `auth_layer`）
- [x] 定向事件只发送给匹配 session、tenant、subscription 的连接（`should_forward_event` 过滤）
- [x] 未订阅（=收全部）/ 连接关闭 / 队列满（Lagged）有不同处理
- [ ] 连接数/队列深度/丢弃数/发送延迟 Prometheus 指标（follow-up）
- [ ] 双会话隔离/断线重连/慢消费者集成测试（follow-up）

## follow-up（独立 PR）

Prometheus WS 指标 · per-conn 有界 mpsc 背压 · WS 客户端集成测试 · `LayerFull`/`MemoryEvicted`(`evict_stm_messages`)/`MemoryUpdated`(`backfill_one_entry`) 事件 · 去 `#![allow(dead_code)]`。