### PR TITLE
fix(backend): 启动 distillation worker——auto-trigger 不再让任务永远 pending (#84/#88)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -162,6 +162,18 @@ async fn main() {
     .expect("Failed to initialize memory transfer service");
     tracing::info!("Memory transfer service initialized successfully");
 
+    // Issue #84/#88: start the distillation worker. Distillation is enabled by
+    // default (DistillationConfig::default) and `memory_transfer` auto-enqueues
+    // L0→L1 jobs after each STM→LTM transfer — but the worker that drains the
+    // `distillation_jobs` queue was never started, so jobs sat `pending`
+    // forever. Starting it closes the 采集→提炼 half of the loop (real L1
+    // extraction via AtomExtractor → `distillation_atoms`; L2/L3 remain
+    // placeholders). Non-critical: log+continue on failure rather than aborting
+    // startup — the app is usable without background distillation.
+    if let Err(e) = crate::services::distillation::init_distillation_service().await {
+        tracing::warn!("Distillation worker failed to start (non-critical): {e}");
+    }
+
     let app = axum_routers::create_router().layer(hoops::cors_hoop());
     tracing::info!("🔄 Listening on {}", &config.listen_addr);
 


### PR DESCRIPTION
## 目标

Distillation **默认 enabled**（`DistillationConfig::default().enabled = true`），且 `memory_transfer` 在每次 STM→LTM transfer 后**自动 enqueue L0→L1 任务**（`services/memory_transfer.rs:237`）。但 `init_distillation_service()`（`services/distillation/worker.rs:260`）**从不在 main.rs 调用** → `start()` 不跑 → worker 循环不 spawn → `distillation_jobs` 队列里的任务**永远 pending**。作者意图（enabled）但漏了启动调用——本 PR 补上。

## 变更

- `main.rs`：在 memory_transfer init 之后调 `init_distillation_service().await`。worker 读 `config.distillation.worker_poll_interval_seconds`，spawn 后台 `loop { process_pending_jobs → list_scheduled_tenants → claim_next_job → process_l0_to_l1（真实 L1 提取 → distillation_atoms）/ l1_to_l2 / l2_to_l3（占位）→ complete/fail }`。
- 非关键：失败 `warn`+continue，不阻断启动（app 没 distillation 也能用）。
- `start()` 已在 `enabled=false` 时 no-op，故无 config 变更。

## 影响

关闭 #84 闭环的**采集→提炼半边**：auto-trigger 的 L0→L1 任务现在真正被 worker 消费、跑 LLM 提取、写 `distillation_atoms`。L2/L3 仍是占位（follow-up）。属 distillation 孤儿子系统接线的同一类（同 #86 `init_ws_manager`）。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets  # 0 error
cargo test --lib           # 431 passed / 0 failed / 3 ignored
\`\`\`

手动 smoke：起 server + 触发一次 STM→LTM transfer → 日志见 `Starting distillation worker` + 该 transfer 的 `l0_to_l1` job 从 `pending` → `completed`、`distillation_atoms` 有新行（需 Ollama 可达；不可达则 job `failed` 优雅 log，不影响启动或其他路径）。

## follow-up（独立 PR）

- 实现 PG 路径的 L2（consolidation）/L3（persona）（现 `process_l1_to_l2`/`process_l2_to_l3` 占位返 Ok(0)）。
- 统一 PG vs SQLite 两套 distillation 后端（`db/distillation.rs` vs `services/distillation/repository.rs`，schema/类型不一致）。
- 让 worker 用 `distillation_atoms.is_active`/`superseded_by` 做冲突/版本（现 L1 只新建不 deactivate 旧的）。
- L0/Scenario 模型 + ADR（#88 验收：L0-L3↔STM/LTM/KG/MM 映射）。