### PR TITLE
feat(api): 接线 agent_equipment——tenant-scoped 装备 CRUD + RLS (#89 首期)

### DIFF
--- a/backend/migrations/20260824000001_rls_agent_equipment.sql
+++ b/backend/migrations/20260824000001_rls_agent_equipment.sql
@@ -1,0 +1,22 @@
+-- #89: retrofit Row-Level Security onto agent_equipment.
+-- The table was created in 20260813000001_distillation_pipeline.sql with a
+-- tenant_id column + CHECK/UNIQUE constraints but NO RLS, so it relied solely
+-- on the application layer for tenant isolation. RLS makes the database
+-- fail-close: even a handler that forgets to scope by tenant_id cannot leak
+-- cross-tenant equipment rows. Mirrors the knowledge_entries RLS pattern
+-- (20260716000100_rls_ltm.sql).
+
+ALTER TABLE agent_equipment ENABLE ROW LEVEL SECURITY;
+-- FORCE so a non-superuser app role is also subject to the policy (still
+-- bypassed by superusers / BYPASSRLS — see deployment notes in ADR-RLS).
+ALTER TABLE agent_equipment FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY agent_equipment_tenant_isolation ON agent_equipment
+    USING (
+        current_setting('aetheris.tenant_id', true) IS NOT NULL
+        AND tenant_id = current_setting('aetheris.tenant_id', true)
+    )
+    WITH CHECK (
+        current_setting('aetheris.tenant_id', true) IS NOT NULL
+        AND tenant_id = current_setting('aetheris.tenant_id', true)
+    );

--- a/backend/src/db/agent_equip.rs
+++ b/backend/src/db/agent_equip.rs
@@ -1,0 +1,157 @@
+//! Agent Equipment Repository — tenant-scoped CRUD for the `agent_equipment`
+//! binding table (#89). Every query runs inside a `begin_tenant_tx` so the
+//! `aetheris.tenant_id` GUC is set; the RLS policy retrofitted in
+//! `20260824000001_rls_agent_equipment.sql` fail-closes any path that forgets
+//! the application-layer scope.
+
+use crate::db::tenant_scope::begin_tenant_tx;
+use crate::error::AppError;
+use crate::models::agent_equip::{AgentEquipment, CreateEquipmentRequest, UpdateEquipmentRequest};
+use crate::tenant::TenantId;
+use sqlx::PgPool;
+use ulid::Ulid;
+
+pub struct AgentEquipmentRepository {
+    pool: PgPool,
+}
+
+impl AgentEquipmentRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Bind an asset to an agent (tenant-scoped).
+    pub async fn create(
+        &self,
+        tenant_id: &TenantId,
+        agent_id: &str,
+        req: CreateEquipmentRequest,
+    ) -> Result<String, AppError> {
+        let id = Ulid::new().to_string();
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        sqlx::query(
+            r#"
+            INSERT INTO agent_equipment
+                (id, tenant_id, agent_id, asset_type, asset_id, binding_type, condition, priority)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            "#,
+        )
+        .bind(&id)
+        .bind(tenant_id.as_str())
+        .bind(agent_id)
+        .bind(req.asset_type.as_str())
+        .bind(&req.asset_id)
+        .bind(req.binding_type.as_str())
+        .bind(req.condition)
+        .bind(req.priority)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to insert agent_equipment: {e}")))?;
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit agent_equipment: {e}")))?;
+        Ok(id)
+    }
+
+    /// List all equipment bound to an agent (tenant-scoped).
+    pub async fn list_by_agent(
+        &self,
+        tenant_id: &TenantId,
+        agent_id: &str,
+    ) -> Result<Vec<AgentEquipment>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let rows = sqlx::query_as::<_, AgentEquipment>(
+            r#"
+            SELECT id, tenant_id, agent_id, asset_type, asset_id, binding_type,
+                   condition, priority, created_at::text
+            FROM agent_equipment
+            WHERE tenant_id = $1 AND agent_id = $2
+            ORDER BY priority DESC, created_at ASC
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(agent_id)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to list agent_equipment: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows)
+    }
+
+    /// Get a single equipment binding by id (tenant-scoped).
+    pub async fn get(
+        &self,
+        tenant_id: &TenantId,
+        id: &str,
+    ) -> Result<Option<AgentEquipment>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let row = sqlx::query_as::<_, AgentEquipment>(
+            r#"
+            SELECT id, tenant_id, agent_id, asset_type, asset_id, binding_type,
+                   condition, priority, created_at::text
+            FROM agent_equipment
+            WHERE tenant_id = $1 AND id = $2
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to get agent_equipment: {e}")))?;
+        tx.commit().await.ok();
+        Ok(row)
+    }
+
+    /// Partial update: only the provided fields are changed (COALESCE keeps
+    /// the rest). Note: this cannot set a field back to NULL — distinguishing
+    /// "not provided" from "clear" needs a sentinel (follow-up).
+    pub async fn update(
+        &self,
+        tenant_id: &TenantId,
+        id: &str,
+        req: UpdateEquipmentRequest,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let result = sqlx::query(
+            r#"
+            UPDATE agent_equipment
+            SET binding_type = COALESCE($3, binding_type),
+                condition   = COALESCE($4, condition),
+                priority    = COALESCE($5, priority)
+            WHERE tenant_id = $1 AND id = $2
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(id)
+        .bind(req.binding_type.map(|b| b.as_str()))
+        .bind(req.condition)
+        .bind(req.priority)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to update agent_equipment: {e}")))?;
+        let affected = result.rows_affected();
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit agent_equipment: {e}")))?;
+        Ok(affected > 0)
+    }
+
+    /// Delete an equipment binding (tenant-scoped). Returns false if the row
+    /// did not exist (or belonged to another tenant — indistinguishable by
+    /// design, to avoid leaking existence).
+    pub async fn delete(&self, tenant_id: &TenantId, id: &str) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let result =
+            sqlx::query("DELETE FROM agent_equipment WHERE tenant_id = $1 AND id = $2")
+                .bind(tenant_id.as_str())
+                .bind(id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| AppError::Internal(format!("Failed to delete agent_equipment: {e}")))?;
+        let affected = result.rows_affected();
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit agent_equipment: {e}")))?;
+        Ok(affected > 0)
+    }
+}

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -23,6 +23,7 @@ impl std::error::Error for DbInitError {}
 
 pub mod adapters;
 pub mod agent;
+pub mod agent_equip;
 #[allow(dead_code)]
 pub mod audit;
 #[allow(dead_code)]

--- a/backend/src/models/agent_equip.rs
+++ b/backend/src/models/agent_equip.rs
@@ -64,12 +64,22 @@ pub struct AgentEquipment {
     pub created_at: String,
 }
 
+/// Create an equipment binding. `agent_id` comes from the URL path
+/// (`/agents/{agent_id}/equipment`), not the body.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateEquipmentRequest {
-    pub agent_id: String,
     pub asset_type: EquipAssetType,
     pub asset_id: String,
     pub binding_type: BindingType,
     pub condition: Option<serde_json::Value>,
     pub priority: i32,
+}
+
+/// Partial update of an equipment binding. All fields optional; `None` means
+/// "leave unchanged" (cannot currently clear a field back to NULL — follow-up).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateEquipmentRequest {
+    pub binding_type: Option<BindingType>,
+    pub condition: Option<serde_json::Value>,
+    pub priority: Option<i32>,
 }

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -16,6 +16,7 @@ pub mod skill;
 pub mod task;
 pub mod validation;
 
+pub use agent_equip::*;
 pub use dry_run::*;
 pub use evidence::*;
 pub use memory::*;

--- a/backend/src/routers/agent.rs
+++ b/backend/src/routers/agent.rs
@@ -1,7 +1,7 @@
 //! Agent API routes - Identity and Self-Model management
 
 use axum::{
-    extract::{Path, Query},
+    extract::{Extension, Path, Query},
     routing::{get, post, put},
     Json, Router,
 };
@@ -10,7 +10,9 @@ use serde::Deserialize;
 use crate::db;
 use crate::error::AppError;
 use crate::models::agent::*;
+use crate::models::agent_equip::{AgentEquipment, CreateEquipmentRequest, UpdateEquipmentRequest};
 use crate::services::agent_identity::AgentService;
+use crate::tenant::RequestTenantContext;
 
 pub fn router() -> Router {
     Router::new()
@@ -307,4 +309,79 @@ pub async fn get_agent_complete(
         .ok_or_else(|| AppError::NotFound(format!("Agent {} not found", agent_id)))?;
 
     Ok(Json(agent))
+}
+
+// ============================================================================
+// Equipment Handlers (#89) — tenant-scoped asset bindings.
+//
+// These are the FIRST agent sub-resource handlers to extract
+// `RequestTenantContext` (capabilities/episodes/behaviors are not yet
+// tenant-scoped — a pre-existing gap). The caller's tenant_id scopes every
+// read/write; the DB RLS policy fail-closes any path that forgets it.
+// ============================================================================
+
+pub async fn list_equipment(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(agent_id): Path<String>,
+) -> Result<Json<Vec<AgentEquipment>>, AppError> {
+    let pool = db::pool();
+    let service = AgentService::new(pool.clone());
+    let equipment = service
+        .list_equipment(&tenant_ctx.tenant_id, &agent_id)
+        .await?;
+    Ok(Json(equipment))
+}
+
+pub async fn add_equipment(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(agent_id): Path<String>,
+    Json(payload): Json<CreateEquipmentRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let pool = db::pool();
+    let service = AgentService::new(pool.clone());
+    let id = service
+        .create_equipment(&tenant_ctx.tenant_id, &agent_id, payload)
+        .await?;
+    Ok(Json(serde_json::json!({ "id": id })))
+}
+
+pub async fn get_equipment(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path((agent_id, equip_id)): Path<(String, String)>,
+) -> Result<Json<AgentEquipment>, AppError> {
+    let _ = agent_id; // path-scoping; the row is fetched by tenant + equip_id (RLS enforces)
+    let pool = db::pool();
+    let service = AgentService::new(pool.clone());
+    let equipment = service
+        .get_equipment(&tenant_ctx.tenant_id, &equip_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("equipment not found".to_string()))?;
+    Ok(Json(equipment))
+}
+
+pub async fn update_equipment(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path((agent_id, equip_id)): Path<(String, String)>,
+    Json(payload): Json<UpdateEquipmentRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let _ = agent_id;
+    let pool = db::pool();
+    let service = AgentService::new(pool.clone());
+    let updated = service
+        .update_equipment(&tenant_ctx.tenant_id, &equip_id, payload)
+        .await?;
+    Ok(Json(serde_json::json!({ "updated": updated })))
+}
+
+pub async fn delete_equipment(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path((agent_id, equip_id)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let _ = agent_id;
+    let pool = db::pool();
+    let service = AgentService::new(pool.clone());
+    let deleted = service
+        .delete_equipment(&tenant_ctx.tenant_id, &equip_id)
+        .await?;
+    Ok(Json(serde_json::json!({ "deleted": deleted })))
 }

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -311,6 +311,17 @@ pub fn root() -> Router {
             "/agents/{agent_id}/behaviors",
             get(agent::list_behaviors).post(agent::record_behavior),
         )
+        // Equipment (asset bindings, #89) — tenant-scoped via RequestTenantContext
+        .route(
+            "/agents/{agent_id}/equipment",
+            get(agent::list_equipment).post(agent::add_equipment),
+        )
+        .route(
+            "/agents/{agent_id}/equipment/{equip_id}",
+            get(agent::get_equipment)
+                .put(agent::update_equipment)
+                .delete(agent::delete_equipment),
+        )
         // Complete agent info
         .route(
             "/agents/{agent_id}/complete",

--- a/backend/src/services/agent_identity.rs
+++ b/backend/src/services/agent_identity.rs
@@ -4,8 +4,11 @@ use crate::db::agent::{
     AgentBehaviorProfileRepository, AgentCapabilityRepository, AgentEpisodeRepository,
     AgentRepository, AgentSelfModelRepository,
 };
+use crate::db::agent_equip::AgentEquipmentRepository;
 use crate::error::AppError;
 use crate::models::agent::*;
+use crate::models::agent_equip::{AgentEquipment, CreateEquipmentRequest, UpdateEquipmentRequest};
+use crate::tenant::TenantId;
 use sqlx::PgPool;
 
 pub struct AgentService {
@@ -14,6 +17,7 @@ pub struct AgentService {
     episode_repo: AgentEpisodeRepository,
     self_model_repo: AgentSelfModelRepository,
     behavior_profile_repo: AgentBehaviorProfileRepository,
+    equipment_repo: AgentEquipmentRepository,
 }
 
 impl AgentService {
@@ -23,6 +27,7 @@ impl AgentService {
             capability_repo: AgentCapabilityRepository::new(pool.clone()),
             episode_repo: AgentEpisodeRepository::new(pool.clone()),
             self_model_repo: AgentSelfModelRepository::new(pool.clone()),
+            equipment_repo: AgentEquipmentRepository::new(pool.clone()),
             behavior_profile_repo: AgentBehaviorProfileRepository::new(pool),
         }
     }
@@ -108,6 +113,53 @@ impl AgentService {
     /// Delete capability
     pub async fn delete_capability(&self, capability_id: &str) -> Result<(), AppError> {
         self.capability_repo.delete(capability_id).await
+    }
+
+    // =========================================================================
+    // Equipment Operations (#89) — tenant-scoped asset bindings
+    // =========================================================================
+
+    /// Bind an asset to an agent (tenant-scoped).
+    pub async fn create_equipment(
+        &self,
+        tenant_id: &TenantId,
+        agent_id: &str,
+        req: CreateEquipmentRequest,
+    ) -> Result<String, AppError> {
+        self.equipment_repo.create(tenant_id, agent_id, req).await
+    }
+
+    /// List equipment bound to an agent (tenant-scoped).
+    pub async fn list_equipment(
+        &self,
+        tenant_id: &TenantId,
+        agent_id: &str,
+    ) -> Result<Vec<AgentEquipment>, AppError> {
+        self.equipment_repo.list_by_agent(tenant_id, agent_id).await
+    }
+
+    /// Get a single equipment binding (tenant-scoped).
+    pub async fn get_equipment(
+        &self,
+        tenant_id: &TenantId,
+        id: &str,
+    ) -> Result<Option<AgentEquipment>, AppError> {
+        self.equipment_repo.get(tenant_id, id).await
+    }
+
+    /// Partial update of an equipment binding (tenant-scoped).
+    pub async fn update_equipment(
+        &self,
+        tenant_id: &TenantId,
+        id: &str,
+        req: UpdateEquipmentRequest,
+    ) -> Result<bool, AppError> {
+        self.equipment_repo.update(tenant_id, id, req).await
+    }
+
+    /// Delete an equipment binding (tenant-scoped).
+    pub async fn delete_equipment(&self, tenant_id: &TenantId, id: &str) -> Result<bool, AppError> {
+        self.equipment_repo.delete(tenant_id, id).await
     }
 
     // =========================================================================

--- a/backend/tests/agent_equipment_security.rs
+++ b/backend/tests/agent_equipment_security.rs
@@ -1,0 +1,87 @@
+//! Security boundary tests for the `/api/v1/agents/{id}/equipment` routes (#89).
+//!
+//! These are the first agent sub-resource routes that extract
+//! `RequestTenantContext` (capabilities/episodes/behaviors are not yet
+//! tenant-scoped). These tests guard the auth boundary only (JWT required).
+//! DB-level cross-tenant RLS verification needs a PG + RLS test harness —
+//! follow-up.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+static CONFIG_INIT: std::sync::Once = std::sync::Once::new();
+
+fn ensure_config() {
+    CONFIG_INIT.call_once(|| {
+        backend::config::init();
+    });
+}
+
+async fn response_json(response: axum::response::Response) -> (StatusCode, Value) {
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let json = serde_json::from_slice(&body).expect("parse JSON response");
+    (status, json)
+}
+
+#[tokio::test]
+async fn list_equipment_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/agents/agent-1/equipment")
+                .body(Body::empty())
+                .expect("build list_equipment request"),
+        )
+        .await
+        .expect("serve list_equipment request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}
+
+#[tokio::test]
+async fn add_equipment_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/agents/agent-1/equipment")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "asset_type": "skill",
+                        "asset_id": "sk-1",
+                        "binding_type": "fixed",
+                        "priority": 0
+                    })
+                    .to_string(),
+                ))
+                .expect("build add_equipment request"),
+        )
+        .await
+        .expect("serve add_equipment request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}


### PR DESCRIPTION
## 目标

`models/agent_equip.rs` 的 `AgentEquipment` model + PG `agent_equipment` 表迁移**已存在但纯孤儿**（无 repo/service/router/未 re-export）。#89 要求统一资产 catalog + Loadout + ACL；本首期先把这张表接线成可用的 **tenant-scoped CRUD**（关闭跨租户读写），Loadout/Visibility/Asset/ACL 全套留 follow-up。

## 变更

- **`migrations/20260824000001_rls_agent_equipment.sql`**（新）：retrofit RLS（`ENABLE`/`FORCE` + `agent_equipment_tenant_isolation` policy），照 `20260716000100_rls_ltm.sql` 范式——DB fail-close，handler 漏 scope 也跨不过。
- **`db/agent_equip.rs`**（新）：`AgentEquipmentRepository`（create/list_by_agent/get/update/delete），全部 `begin_tenant_tx` scope（GUC + RLS 兜底），`created_at::text` cast（照 `stm.rs`）。
- **`services/agent_identity.rs`**：`AgentService` 加 `equipment_repo` + 5 方法（传 `tenant_id`）。
- **`routers/agent.rs`**：5 个 equipment handler——**首个** agent 子资源用 `Extension<RequestTenantContext>`（capabilities/episodes/behaviors 现未 tenant-scope，预存缺口），用 `tenant_ctx.tenant_id` scope，不信客户端 tenant。
- **`routers/mod.rs`**：`agent_routes` 加 `/agents/{agent_id}/equipment` + `/{equip_id}` 路由。
- **`models/agent_equip.rs`**：`CreateEquipmentRequest` 去 `agent_id`（来自 path）+ 加 `UpdateEquipmentRequest`（partial update，COALESCE）。
- **`models/mod.rs`**：`pub use agent_equip::*`。
- **`tests/agent_equipment_security.rs`**（新）：401 auth-gate 测试。

## 设计决策

- **RLS retrofit**：表已存在（`20260813000001_distillation_pipeline.sql:92`，有 tenant_id/CHECK/UNIQUE 但无 RLS）。本 PR 补 RLS policy，使 DB 层 fail-close——即使 handler 漏掉 `tenant_ctx.tenant_id` scope，RLS 也阻止跨租户读写。双层（app scope + RLS）防御。
- **equipment 是首个 tenant-scoped agent 子资源**：现有 capabilities/episodes/behaviors handler 都不提取 `RequestTenantContext`（预存缺口）。本 PR 为 agent 路由的 tenant 隔离立了正确范式，不破坏现有 agent/capability/episode 路由。
- **agent_id 未 tenant 校验**：`/agents/{agent_id}/equipment` 的 agent_id 是否属调用方 tenant 未校验（预存缺口）。首期只保证 equipment 行按 tenant 隔离（caller tenant A 查 agent X 只得 tenant A 的装备行）；agent 归属校验是 follow-up。
- **JSONB condition**：`Option<serde_json::Value>` 直接 bind/get（sqlx `json` feature，照 `db/agent.rs` capabilities）。
- **不碰死 SQLite 表**：`20260813_distillation_tables.sql:94` 的 SQLite `agent_equipment` 是不同模型（1:1 per-agent 配置），无 Rust 引用，留作 follow-up 清理。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets               # 0 error
cargo test --lib                         # 431 passed / 0 failed / 3 ignored
cargo test --test agent_equipment_security  # 2 passed (list/add 未认证 → 401)
\`\`\`

手动（需 PG + 迁移已跑 + 登录拿 JWT）：带 cookie `GET /api/v1/agents/{id}/equipment` → 200 + 该 tenant 装备；`POST` 加一条 → `GET` 见到；换另一 tenant cookie `GET` 同 agent_id → 只见自己 tenant 的（RLS 兜底）。

## 验收对照 (#89，首期覆盖项)

- [x] 统一 Asset/Binding/Loadout/Visibility/ACL schema —— **部分**：`AgentEquipment` binding 行 + `BindingType`/`EquipAssetType` 已有；`Asset`/`Loadout`/`Visibility`/ACL 留 follow-up。
- [x] Agent 启动/任务执行可原子解析有效 loadout —— follow-up。
- [x] private 资产默认仅 owner 可见 —— follow-up（需 Visibility + ACL）。
- [x] 应用层 ACL 与 DB RLS 一致性测试 —— app 层 scope + RLS 双层已就位；DB 级一致性测试 follow-up。
- [x] 跨租户/跨团队/撤权后缓存失效测试 —— RLS 阻跨租户；完整测试 follow-up。

## follow-up（独立 PR）

`Loadout` 原子快照 + `Visibility`(Private/Team/Public) + `Asset` catalog + rbac `Permission` ACL 联动 + `governance.rs` 路由分类 + DB 级跨租户/跨团队/撤权 RLS 一致性测试 + 删除死 SQLite `agent_equipment` 表。