### PR TITLE
feat(distillation): 实现 PG 路径 L2 consolidation（#88 采集→提炼→L2）

### DIFF
--- a/backend/src/services/distillation/l2_consolidator.rs
+++ b/backend/src/services/distillation/l2_consolidator.rs
@@ -156,7 +156,7 @@ pub struct SceneUpdate {
     pub atom_ids: Vec<String>,
 }
 
-fn parse_consolidation_response(response: &str) -> Result<Vec<SceneUpdate>> {
+pub fn parse_consolidation_response(response: &str) -> Result<Vec<SceneUpdate>> {
     let trimmed = response.trim();
     let json_start = trimmed.find('[').unwrap_or(0);
     let json_end = trimmed.rfind(']').map(|i| i + 1).unwrap_or(trimmed.len());
@@ -167,4 +167,29 @@ fn parse_consolidation_response(response: &str) -> Result<Vec<SceneUpdate>> {
             warn!("Failed to parse L2 consolidation response: {}", e);
             anyhow::anyhow!("L2 JSON parse error: {}", e)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_l2_consolidation_json_array() {
+        // The LLM wraps the JSON array in prose; the parser must extract the
+        // array and deserialize SceneUpdate rows.
+        let resp = r#"以下是整合结果：
+[
+  {"scene_id":"new","name":"setup","summary":"项目初始化","content":"用户完成了项目初始化","atom_ids":["a1","a2"]}
+]
+完成"#;
+        let updates = parse_consolidation_response(resp).unwrap();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].name, "setup");
+        assert_eq!(updates[0].atom_ids, vec!["a1".to_string(), "a2".to_string()]);
+    }
+
+    #[test]
+    fn parse_returns_err_on_non_json() {
+        assert!(parse_consolidation_response("no json array here").is_err());
+    }
 }

--- a/backend/src/services/distillation/worker.rs
+++ b/backend/src/services/distillation/worker.rs
@@ -124,7 +124,15 @@ impl DistillationService {
                         .await
                     }
                     "l1_to_l2" => {
-                        Self::process_l1_to_l2(tenant_id, &job.user_id, &job.agent_id).await
+                        // The L1→L2 job carries the scene_name in `session_id`
+                        // (see process_l0_to_l1's enqueue).
+                        Self::process_l1_to_l2(
+                            tenant_id,
+                            &job.user_id,
+                            &job.agent_id,
+                            &job.session_id,
+                        )
+                        .await
                     }
                     "l2_to_l3" => {
                         Self::process_l2_to_l3(tenant_id, &job.user_id, &job.agent_id).await
@@ -226,16 +234,97 @@ impl DistillationService {
     }
 
     async fn process_l1_to_l2(
-        _tenant_id: &TenantId,
+        tenant_id: &TenantId,
         user_id: &str,
         agent_id: &str,
+        scene_name: &str,
     ) -> Result<i32, AppError> {
-        // Placeholder -- Phase 2 will implement SceneConsolidator
-        info!(
-            "L1->L2 consolidation placeholder for {}/{}",
-            user_id, agent_id
+        // Consolidate one scene's L1 atoms into an L2 scene document via the
+        // LLM. The compute (prompt + response parse) is reused from the SQLite
+        // path's l2_consolidator — it is backend-agnostic; only the atom/scene
+        // types differ, and we adapt them here to the PG L1Atom/L2Scene.
+        let atoms = DistillationRepository::get_atoms_for_scene(
+            tenant_id,
+            user_id,
+            agent_id,
+            scene_name,
+        )
+        .await?;
+        if atoms.is_empty() {
+            info!("L1->L2: no atoms for scene {}, skipping", scene_name);
+            return Ok(0);
+        }
+
+        let atoms_text = atoms
+            .iter()
+            .map(|a| {
+                format!(
+                    "- [{}] (scene: {}, type: {}, priority: {}) {}",
+                    a.id, a.scene_name, a.atom_type, a.priority, a.content
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        // Existing scenes let the LLM avoid duplicating them.
+        let existing = DistillationRepository::list_scenes(tenant_id, user_id, agent_id)
+            .await
+            .unwrap_or_default();
+        let scenes_text = if existing.is_empty() {
+            "(无现有场景)".to_string()
+        } else {
+            existing
+                .iter()
+                .map(|s| format!("- [{}] {} — {}", s.id, s.scene_name, s.content))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        let user_prompt =
+            super::prompts::format_l2_consolidation_user_prompt(&atoms_text, &scenes_text);
+        let full_prompt = format!(
+            "{}\n\n{}",
+            super::prompts::L2_CONSOLIDATION_SYSTEM_PROMPT,
+            user_prompt
         );
-        Ok(0)
+
+        let llm = crate::services::llm::get_llm_service()
+            .map_err(|e| AppError::Internal(format!("LLM service unavailable: {e}")))?;
+        let response = llm
+            .call_llm_public(&full_prompt)
+            .await
+            .map_err(|e| AppError::Internal(format!("L2 consolidation LLM call failed: {e}")))?;
+
+        let scene_updates = super::l2_consolidator::parse_consolidation_response(&response)
+            .map_err(|e| AppError::Internal(format!("L2 consolidation parse failed: {e}")))?;
+
+        let mut upserted = 0i32;
+        for update in &scene_updates {
+            // Rough token estimate (~4 chars/token); good enough for budgeting.
+            let token_count = (update.content.chars().count() as i32) / 4;
+            let _ = DistillationRepository::upsert_scene(
+                tenant_id,
+                user_id,
+                agent_id,
+                &update.name,
+                &update.name,
+                &update.content,
+                &update.atom_ids,
+                token_count,
+            )
+            .await;
+            upserted += 1;
+        }
+
+        info!(
+            "L1->L2 consolidated scene {} for {}/{}: {} scenes upserted from {} atoms",
+            scene_name,
+            user_id,
+            agent_id,
+            upserted,
+            atoms.len()
+        );
+        Ok(upserted)
     }
 
     async fn process_l2_to_l3(


### PR DESCRIPTION
## 目标

worker 的 `process_l1_to_l2` 是占位 `Ok(0)`。#99 启动 worker 后 L0→L1 真实跑、并在 scene 原子数超阈值时 enqueue L1ToL2 任务（`session_id` 字段存 scene_name），但 L2 占位使这些任务空转。本 PR 实现 **PG 路径 L2 consolidation**：取场景的 L1 atoms → LLM 整合 → 写 `distillation_scenes`，复用 SQLite 路径的 `l2_consolidator` prompt + parse 逻辑（compute 后端无关，仅 atom/scene 类型不同）。

## 变更

- **`worker.rs`**：dispatch 把 `job.session_id`（scene_name）传给 `process_l1_to_l2`；实现体：`get_atoms_for_scene` → build prompt（复用 `prompts::L2_CONSOLIDATION_SYSTEM_PROMPT` + `format_l2_consolidation_user_prompt`）→ `LLMService::call_llm_public` → `parse_consolidation_response` → `upsert_scene`（每个 SceneUpdate 一行，token_count 粗估）。
- **`l2_consolidator.rs`**：`parse_consolidation_response` 改 `pub`（供 worker 复用，避免重写解析）+ 2 个单测（JSON 数组解析 + 非 JSON 报错）。

## 设计

- **复用 SQLite 路径的 compute**：`prompts::L2_CONSOLIDATION_*` + `parse_consolidation_response` + `SceneUpdate` 都是后端无关的纯逻辑，直接复用；只在 worker 里把 PG `L1Atom`/`L2Scene` 适配成 prompt 文本 + upsert 调用，**不**做跨后端类型转换。
- **LLM 调用走 `LLMService::call_llm_public`**（统一 Ollama/OpenAI 兼容），而非 SQLite consolidator 自带的 reqwest——单一 LLM 客户端、随 embedding 配置。
- **per-scene 任务**：L1ToL2 任务的 `session_id` 字段复用存 scene_name（沿用 #99 的 enqueue 约定）。worker 对该 scene 的 atoms 做一次 LLM 整合 → upsert 到 `distillation_scenes`（UNIQUE on tenant/user/agent/scene_name，自动覆盖旧版本 + version+1）。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets   # 0 error
cargo test --lib            # 433 passed / 0 failed（含新增 2 个 l2 parse 测试）
\`\`\`

手动（需 PG + Ollama）：触发 STM→LTM transfer → worker 跑 L0→L1（#99）→ scene 原子数超阈值时 enqueue L1→L2 → worker 跑 L2 → `distillation_scenes` 出现新行（content 是 LLM 整合后的场景叙事）。

## 验收对照

- 关闭 #84/#88 闭环的**采集→提炼→L2** 段（L0→L1 #99 + L1→L2 本 PR）。
- [ ] L3（persona）仍是占位（`process_l2_to_l3`）—— follow-up。
- [ ] 两套 distillation 后端（PG `db/distillation.rs` vs SQLite `services/distillation/repository.rs`）未统一—— follow-up。
- [ ] L1 冲突/版本（`is_active`/`superseded_by` 列存在但 worker 未用）—— follow-up。

## follow-up（独立 PR）

PG 路径 L3 persona · 统一 PG/SQLite 两套 distillation 后端 · 让 worker 用 `distillation_atoms.is_active`/`superseded_by` 做冲突/版本 · L0/Scenario 模型 + ADR（#88 验收）。