### PR TITLE
feat(distillation): 实现 PG 路径 L3 persona——闭环 L0→L1→L2→L3 (#88)

### DIFF
--- a/backend/src/services/distillation/worker.rs
+++ b/backend/src/services/distillation/worker.rs
@@ -316,6 +316,21 @@ impl DistillationService {
             upserted += 1;
         }
 
+        // After consolidating, schedule L3 persona regeneration if the user has
+        // enough scenes. No dedup — upsert_persona is idempotent (version bump);
+        // a duplicate L2ToL3 just regenerates. Dedup is a follow-up.
+        let persona_threshold = config::get().distillation.persona_rebuild_scene_threshold;
+        if (existing.len() as u32) >= persona_threshold {
+            let _ = Self::enqueue_job(
+                tenant_id,
+                user_id,
+                agent_id,
+                "",
+                DistillationJobType::L2ToL3,
+            )
+            .await;
+        }
+
         info!(
             "L1->L2 consolidated scene {} for {}/{}: {} scenes upserted from {} atoms",
             scene_name,
@@ -328,16 +343,72 @@ impl DistillationService {
     }
 
     async fn process_l2_to_l3(
-        _tenant_id: &TenantId,
+        tenant_id: &TenantId,
         user_id: &str,
         agent_id: &str,
     ) -> Result<i32, AppError> {
-        // Placeholder -- Phase 2 will implement PersonaBuilder
-        info!(
-            "L2->L3 persona build placeholder for {}/{}",
-            user_id, agent_id
+        // Generate (or regenerate) the user's L3 persona from their L2 scenes
+        // via the LLM. The compute (prompt) is reused from the SQLite path's
+        // l3_persona; the LLM returns the persona text directly (no JSON parse,
+        // unlike L2). upsert_persona bumps version on conflict (idempotent).
+        let scenes = DistillationRepository::list_scenes(tenant_id, user_id, agent_id)
+            .await
+            .unwrap_or_default();
+        if scenes.is_empty() {
+            info!("L2->L3: no scenes for {}/{}, skipping", user_id, agent_id);
+            return Ok(0);
+        }
+
+        let existing = DistillationRepository::get_persona(tenant_id, user_id, agent_id)
+            .await
+            .unwrap_or_default();
+        let existing_text = existing
+            .as_ref()
+            .map(|p| p.profile_content.as_str())
+            .unwrap_or("(尚无画像)");
+
+        let scene_contents = scenes
+            .iter()
+            .map(|s| format!("## {}\n{}\n", s.scene_name, s.content))
+            .collect::<Vec<_>>()
+            .join("\n---\n");
+
+        let user_prompt =
+            super::prompts::format_l3_persona_user_prompt(existing_text, &scene_contents);
+        let full_prompt = format!(
+            "{}\n\n{}",
+            super::prompts::L3_PERSONA_SYSTEM_PROMPT,
+            user_prompt
         );
-        Ok(0)
+
+        let llm = crate::services::llm::get_llm_service()
+            .map_err(|e| AppError::Internal(format!("LLM service unavailable: {e}")))?;
+        let persona_content = llm
+            .call_llm_public(&full_prompt)
+            .await
+            .map_err(|e| AppError::Internal(format!("L3 persona LLM call failed: {e}")))?;
+
+        let scene_ids: Vec<String> = scenes.iter().map(|s| s.id.clone()).collect();
+        let token_count = (persona_content.chars().count() as i32) / 4;
+
+        let _ = DistillationRepository::upsert_persona(
+            tenant_id,
+            user_id,
+            agent_id,
+            persona_content.trim(),
+            &scene_ids,
+            token_count,
+        )
+        .await;
+
+        info!(
+            "L2->L3 persona generated for {}/{}: {} scenes, content_len={}",
+            user_id,
+            agent_id,
+            scene_ids.len(),
+            persona_content.len()
+        );
+        Ok(1)
     }
 }
 


### PR DESCRIPTION
## 目标

`process_l2_to_l3` 是最后一个 distillation 占位。#101 实现 L2 后，L2ToL3 任务无人 enqueue（L2 实现没 enqueue 它），故光实现 L3 不够。本 PR：在 L2 整合后（scene 数 ≥ `persona_rebuild_scene_threshold`）**enqueue L2ToL3** + 实现 `process_l2_to_l3`。**采集→提炼→L2→L3 现已在 PG 路径完整闭环。**

## 变更

- **`worker.rs`**：
  - `process_l1_to_l2` 末尾：scene 数 ≥ `persona_rebuild_scene_threshold` 时 enqueue L2ToL3（无 dedup——`upsert_persona` 幂等 version+1，重复 L2ToL3 只是多生成一次，dedup 列 follow-up）。
  - `process_l2_to_l3` 实现：`list_scenes` + `get_persona`（现有 persona 文本作"尚无画像"基线）→ `prompts::L3_PERSONA_*` → `LLMService::call_llm_public` → `upsert_persona`（scene_ids + token_count）。

## 设计

- **与 L2 平行但更简**：L2 的 LLM 返回 JSON 数组（需 `parse_consolidation_response`）；L3 的 LLM 直接返回 persona 文本，无 parse 步——直接 `upsert_persona(profile_content=trimmed text)`。
- **复用 l3_persona 的 prompt**（`L3_PERSONA_SYSTEM_PROMPT` + `format_l3_persona_user_prompt`，后端无关），LLM 走 `LLMService::call_llm_public`（统一 Ollama/OpenAI），不沿用 SQLite L3PersonaGenerator 自带的 reqwest。
- **幂等 upsert**：`upsert_persona` 的 `ON CONFLICT (tenant,user,agent) DO UPDATE ... version+1`，重复 L2ToL3 安全（version 递增，不产生重复行）。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets   # 0 error
cargo test --lib            # 433 passed / 0 failed
\`\`\`

手动（需 PG + Ollama）：触发 STM→LTM transfer → L0→L1（#99）→ scene 阈值 → L1→L2（#101）→ scene 数 ≥ persona_rebuild_scene_threshold → L2→L3 → `distillation_personas` 出现/更新 persona 行（profile_content 是 LLM 生成的用户画像）。

## 闭环状态

PG 路径 distillation pipeline 现已**完整闭环**：L0（STM session_messages）→ L1 atoms（#99）→ L2 scenes（#101）→ L3 persona（本 PR）。对应 #84 采集→提炼 段 + #88 L1-L3。

## follow-up（独立 PR）

L2ToL3 enqueue dedup（避免 persona 频繁重生成）· 统一 PG/SQLite 两套 distillation 后端 · 让 worker 用 `distillation_atoms.is_active`/`superseded_by` 做冲突/版本 · L0/Scenario 模型 + ADR（#88 验收 L0-L3↔STM/LTM 映射）。