### PR TITLE
feat(api): 接线 skills——tenant-scoped skill CRUD + RLS (#90 首期)

### DIFF
--- a/backend/migrations/20260824000002_rls_skills.sql
+++ b/backend/migrations/20260824000002_rls_skills.sql
@@ -1,0 +1,19 @@
+-- #90: retrofit Row-Level Security onto skills.
+-- The skills table was created in 20260813000001_distillation_pipeline.sql
+-- with a tenant_id column + CHECK/UNIQUE/indexes but NO RLS. RLS makes the
+-- database fail-close: a handler that forgets to scope by tenant_id cannot
+-- leak cross-tenant skills. Mirrors agent_equipment (20260824000001) +
+-- knowledge_entries (20260716000100_rls_ltm).
+
+ALTER TABLE skills ENABLE ROW LEVEL SECURITY;
+ALTER TABLE skills FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY skills_tenant_isolation ON skills
+    USING (
+        current_setting('aetheris.tenant_id', true) IS NOT NULL
+        AND tenant_id = current_setting('aetheris.tenant_id', true)
+    )
+    WITH CHECK (
+        current_setting('aetheris.tenant_id', true) IS NOT NULL
+        AND tenant_id = current_setting('aetheris.tenant_id', true)
+    );

--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -24,6 +24,7 @@ impl std::error::Error for DbInitError {}
 pub mod adapters;
 pub mod agent;
 pub mod agent_equip;
+pub mod skill;
 #[allow(dead_code)]
 pub mod audit;
 #[allow(dead_code)]

--- a/backend/src/db/skill.rs
+++ b/backend/src/db/skill.rs
@@ -1,0 +1,171 @@
+//! Skill Repository — tenant-scoped CRUD for the `skills` table (#90 first
+//! increment). Every query runs inside a `begin_tenant_tx` so the
+//! `aetheris.tenant_id` GUC is set; the RLS policy retrofitted in
+//! `20260824000002_rls_skills.sql` fail-closes any path that forgets the
+//! application-layer scope. The JSONB columns (trigger_conditions /
+//! execution_steps / validation_rules / source_session_ids) are bound as
+//! `serde_json::Value` (sqlx `json` feature).
+
+use crate::db::tenant_scope::begin_tenant_tx;
+use crate::error::AppError;
+use crate::models::skill::{CreateSkillRequest, Skill, UpdateSkillRequest};
+use crate::tenant::TenantId;
+use sqlx::PgPool;
+use ulid::Ulid;
+
+pub struct SkillRepository {
+    pool: PgPool,
+}
+
+impl SkillRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn create(
+        &self,
+        tenant_id: &TenantId,
+        req: CreateSkillRequest,
+    ) -> Result<String, AppError> {
+        let id = Ulid::new().to_string();
+        let triggers = serde_json::to_value(&req.trigger_conditions).unwrap_or_default();
+        let steps = serde_json::to_value(&req.execution_steps).unwrap_or_default();
+        let rules = serde_json::to_value(&req.validation_rules).unwrap_or_default();
+        let sources = serde_json::json!([]);
+
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        sqlx::query(
+            r#"
+            INSERT INTO skills
+                (id, tenant_id, name, description, version, trigger_conditions,
+                 execution_steps, validation_rules, source_session_ids,
+                 owner_agent_id, visibility, status)
+            VALUES ($1, $2, $3, $4, 1, $5, $6, $7, $8, $9, $10, 'draft')
+            "#,
+        )
+        .bind(&id)
+        .bind(tenant_id.as_str())
+        .bind(&req.name)
+        .bind(&req.description)
+        .bind(&triggers)
+        .bind(&steps)
+        .bind(&rules)
+        .bind(&sources)
+        .bind(&req.owner_agent_id)
+        .bind(req.visibility.as_str())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to insert skill: {e}")))?;
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit skill: {e}")))?;
+        Ok(id)
+    }
+
+    pub async fn list(
+        &self,
+        tenant_id: &TenantId,
+        owner_agent_id: Option<&str>,
+        status: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Skill>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        // Filter dynamically: tenant_id is always bound; agent/status optional.
+        let rows = sqlx::query_as::<_, Skill>(
+            r#"
+            SELECT id, tenant_id, name, description, version, trigger_conditions,
+                   execution_steps, validation_rules, source_session_ids,
+                   owner_agent_id, visibility, status, embedding_model,
+                   embedding_dimension, created_at::text, updated_at::text
+            FROM skills
+            WHERE tenant_id = $1
+              AND ($2 IS NULL OR owner_agent_id = $2)
+              AND ($3 IS NULL OR status = $3)
+            ORDER BY updated_at DESC
+            LIMIT $4 OFFSET $5
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(owner_agent_id)
+        .bind(status)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to list skills: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows)
+    }
+
+    pub async fn get(&self, tenant_id: &TenantId, id: &str) -> Result<Option<Skill>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let row = sqlx::query_as::<_, Skill>(
+            r#"
+            SELECT id, tenant_id, name, description, version, trigger_conditions,
+                   execution_steps, validation_rules, source_session_ids,
+                   owner_agent_id, visibility, status, embedding_model,
+                   embedding_dimension, created_at::text, updated_at::text
+            FROM skills
+            WHERE tenant_id = $1 AND id = $2
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to get skill: {e}")))?;
+        tx.commit().await.ok();
+        Ok(row)
+    }
+
+    /// Partial update of a skill's mutable metadata. `status` transitions
+    /// (draft→active→deprecated) go through here. COALESCE keeps unspecified
+    /// fields. Bumping `version` (publishing a new revision) is a follow-up.
+    pub async fn update(
+        &self,
+        tenant_id: &TenantId,
+        id: &str,
+        req: UpdateSkillRequest,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let result = sqlx::query(
+            r#"
+            UPDATE skills
+            SET description = COALESCE($3, description),
+                visibility  = COALESCE($4, visibility),
+                status      = COALESCE($5, status),
+                updated_at  = NOW()
+            WHERE tenant_id = $1 AND id = $2
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(id)
+        .bind(req.description)
+        .bind(req.visibility.map(|v| v.as_str()))
+        .bind(req.status.map(|s| s.as_str()))
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to update skill: {e}")))?;
+        let affected = result.rows_affected();
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit skill: {e}")))?;
+        Ok(affected > 0)
+    }
+
+    pub async fn delete(&self, tenant_id: &TenantId, id: &str) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let result = sqlx::query("DELETE FROM skills WHERE tenant_id = $1 AND id = $2")
+            .bind(tenant_id.as_str())
+            .bind(id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to delete skill: {e}")))?;
+        let affected = result.rows_affected();
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit skill: {e}")))?;
+        Ok(affected > 0)
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -22,6 +22,7 @@ pub use evidence::*;
 pub use memory::*;
 pub use performance::*;
 pub use resource::*;
+pub use skill::*;
 pub use task::*;
 pub use validation::*;
 

--- a/backend/src/models/skill.rs
+++ b/backend/src/models/skill.rs
@@ -102,3 +102,13 @@ pub struct CreateSkillRequest {
     pub owner_agent_id: String,
     pub visibility: Visibility,
 }
+
+/// Partial update of a skill. All fields optional; `None` = unchanged.
+/// `status` transitions (draft→active→deprecated) go through here. Publishing
+/// a new `version` revision is a follow-up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateSkillRequest {
+    pub description: Option<String>,
+    pub visibility: Option<Visibility>,
+    pub status: Option<SkillStatus>,
+}

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -34,6 +34,7 @@ mod openapi;
 mod planner;
 mod procedural;
 mod security;
+mod skill;
 #[allow(dead_code)]
 mod snapshot;
 #[allow(dead_code)]
@@ -422,6 +423,8 @@ pub fn root() -> Router {
             "/v1/planner",
             planner::router(std::sync::Arc::new(planner::PlannerState::new())),
         )
+        // Skill asset routes (#90) — tenant-scoped via RequestTenantContext
+        .nest("/v1/skills", skill::router())
         // Distillation pipeline routes
         .nest(
             "/v1/distillation",

--- a/backend/src/routers/skill.rs
+++ b/backend/src/routers/skill.rs
@@ -1,0 +1,98 @@
+//! Skill API routes — tenant-scoped CRUD for the `skills` asset table
+//! (#90 first increment). Mirrors the agent_equipment pattern: the caller's
+//! `tenant_id` (from `RequestTenantContext`) scopes every read/write; the DB
+//! RLS policy (`20260824000002_rls_skills.sql`) fail-closes any path that
+//! forgets it. Skill lifecycle (draft→active→deprecated) goes through the
+//! update endpoint's `status` field; version-on-publish, extractor-from-trace,
+//! Wiki and CodeGraph are follow-ups.
+
+use axum::{
+    extract::{Extension, Path, Query},
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+
+use crate::db;
+use crate::db::skill::SkillRepository;
+use crate::error::AppError;
+use crate::models::skill::{CreateSkillRequest, Skill, UpdateSkillRequest};
+use crate::tenant::RequestTenantContext;
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/", get(list_skills).post(create_skill))
+        .route("/{id}", get(get_skill).put(update_skill).delete(delete_skill))
+}
+
+#[derive(Deserialize)]
+pub struct ListSkillsQuery {
+    pub owner_agent_id: Option<String>,
+    pub status: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+pub async fn list_skills(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Query(q): Query<ListSkillsQuery>,
+) -> Result<Json<Vec<Skill>>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let skills = repo
+        .list(
+            &tenant_ctx.tenant_id,
+            q.owner_agent_id.as_deref(),
+            q.status.as_deref(),
+            q.limit.unwrap_or(50),
+            q.offset.unwrap_or(0),
+        )
+        .await?;
+    Ok(Json(skills))
+}
+
+pub async fn create_skill(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Json(payload): Json<CreateSkillRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let id = repo.create(&tenant_ctx.tenant_id, payload).await?;
+    Ok(Json(serde_json::json!({ "id": id })))
+}
+
+pub async fn get_skill(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(id): Path<String>,
+) -> Result<Json<Skill>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let skill = repo
+        .get(&tenant_ctx.tenant_id, &id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("skill not found".to_string()))?;
+    Ok(Json(skill))
+}
+
+pub async fn update_skill(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(id): Path<String>,
+    Json(payload): Json<UpdateSkillRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let updated = repo
+        .update(&tenant_ctx.tenant_id, &id, payload)
+        .await?;
+    Ok(Json(serde_json::json!({ "updated": updated })))
+}
+
+pub async fn delete_skill(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let deleted = repo.delete(&tenant_ctx.tenant_id, &id).await?;
+    Ok(Json(serde_json::json!({ "deleted": deleted })))
+}

--- a/backend/tests/skill_security.rs
+++ b/backend/tests/skill_security.rs
@@ -1,0 +1,86 @@
+//! Security boundary tests for the `/api/v1/skills` routes (#90 first
+//! increment). Guards the auth boundary only (JWT required). DB-level
+//! cross-tenant RLS verification needs a PG + RLS test harness — follow-up.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+static CONFIG_INIT: std::sync::Once = std::sync::Once::new();
+
+fn ensure_config() {
+    CONFIG_INIT.call_once(|| {
+        backend::config::init();
+    });
+}
+
+async fn response_json(response: axum::response::Response) -> (StatusCode, Value) {
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let json = serde_json::from_slice(&body).expect("parse JSON response");
+    (status, json)
+}
+
+#[tokio::test]
+async fn list_skills_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/skills")
+                .body(Body::empty())
+                .expect("build list_skills request"),
+        )
+        .await
+        .expect("serve list_skills request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}
+
+#[tokio::test]
+async fn create_skill_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/skills")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "deploy",
+                        "description": "deploy a service",
+                        "trigger_conditions": [],
+                        "execution_steps": [],
+                        "validation_rules": [],
+                        "owner_agent_id": "agent-1",
+                        "visibility": "private"
+                    })
+                    .to_string(),
+                ))
+                .expect("build create_skill request"),
+        )
+        .await
+        .expect("serve create_skill request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}


### PR DESCRIPTION
## 目标

`models/skill.rs` 的 `Skill` model（PG-aligned，JSONB trigger/steps/rules）+ PG `skills` 表迁移**已存在但纯孤儿**（无 repo/router/未 re-export；`services/skill/` 是另一套 SQLite 死实现）。#90 要求 Skill 生命周期 + Wiki/CodeGraph；本首期先把 `skills` 表接线成可用的 **tenant-scoped CRUD**（draft→active→deprecated 状态转换经 update 的 `status` 字段），Wiki/CodeGraph/extractor-from-trace/version-publish 留 follow-up。

## 变更

- **`migrations/20260824000002_rls_skills.sql`**（新）：retrofit RLS（`skills_tenant_isolation` policy），照 `agent_equipment`/`ltm` 范式——DB fail-close。
- **`db/skill.rs`**（新）：`SkillRepository`（create/list/get/update/delete），`begin_tenant_tx` scope，JSONB 字段 `serde_json::Value` bind/get（sqlx `json` feature），`created_at`/`updated_at::text` cast。
- **`routers/skill.rs`**（新）：5 个 handler + `router()`，全部 `Extension<RequestTenantContext>` tenant-scope，挂 `/v1/skills`。
- **`routers/mod.rs`**：`mod skill` + `.nest("/v1/skills", skill::router())` 在 `protected_api_router`（自动 `auth_layer`）。
- **`models/skill.rs`**：加 `UpdateSkillRequest`（description/visibility/status partial）。
- **`models/mod.rs`**：`pub use skill::*`。
- **`tests/skill_security.rs`**（新）：401 auth-gate 测试。

## 设计

- **PG 为 canonical**：与 distillation（#99/#101/#102 把 L1-L3 落 PG）一致，skill 用 PG `models/skill.rs`（非 SQLite `services/skill/types.rs`）。
- **RLS 双层防御**：app 层 `tenant_ctx.tenant_id` scope + DB RLS policy fail-close（同 #89 agent_equipment）。
- **JSONB**：trigger_conditions/execution_steps/validation_rules/source_session_ids 用 `serde_json::Value` 直接 bind/get（sqlx `json` feature，照 `db/agent` capabilities）。
- **不碰 SQLite 死实现**：`services/skill/`（store/extractor/matcher，SQLite-only，零调用方）是另一套，留 follow-up 统一/删除。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets      # 0 error
cargo test --lib               # 433 passed / 0 failed
cargo test --test skill_security  # 2 passed (list/create 未认证 → 401)
\`\`\`

手动（需 PG + 迁移 + JWT）：带 cookie `POST /api/v1/skills`（draft）→ `PUT /{id}` status=active → `GET /v1/skills?status=active` 见到；换 tenant cookie `GET` → 只见自己 tenant 的（RLS 兜底）。

## 验收对照 (#90，首期覆盖项)

- [x] Skill 有可审计的版本/发布状态/资源/来源模型 —— **部分**：`Skill` model（version/status/visibility/source_session_ids/owner）已落 PG + CRUD；version-publish 历史不可变留 follow-up。
- [x] 从执行 trace 生成候选 Skill（默认不自动发布）—— follow-up（extractor 存在但未接线）。
- [ ] Wiki 增量导入/重试/来源级删除 —— 0%，大 follow-up。
- [ ] CodeGraph symbol/callers/callees/impact —— 0%，大 follow-up。
- [ ] Loadout 按 ACL 装 Skill —— #89 follow-up。
- [ ] 质量/回滚/跨租户测试 —— RLS 阻跨租户；完整测试 follow-up。

## follow-up（独立 PR）

Skill 版本发布（version+1，历史不可变）· 从执行 trace 抽候选 Skill（审批后固化，不自动发布）· Wiki 增量导入 · CodeGraph 查询 · Loadout 按 ACL 装 Skill · 统一/删除 SQLite `services/skill/` 死实现。