### PR TITLE
feat(api): agent loadout——原子解析装备快照（#89 续作）

### DIFF
--- a/backend/src/models/agent_equip.rs
+++ b/backend/src/models/agent_equip.rs
@@ -83,3 +83,16 @@ pub struct UpdateEquipmentRequest {
     pub condition: Option<serde_json::Value>,
     pub priority: Option<i32>,
 }
+
+/// Atomic snapshot of all assets bound to an agent, grouped by asset type
+/// (#89). A first increment: the binding rows grouped; resolving the actual
+/// asset bodies (skill/scene/persona content) by `asset_id` is a follow-up —
+/// callers can fetch each asset by id from its type-specific endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Loadout {
+    pub agent_id: String,
+    pub skills: Vec<AgentEquipment>,
+    pub l1_memories: Vec<AgentEquipment>,
+    pub l2_scenes: Vec<AgentEquipment>,
+    pub l3_personas: Vec<AgentEquipment>,
+}

--- a/backend/src/routers/agent.rs
+++ b/backend/src/routers/agent.rs
@@ -10,7 +10,9 @@ use serde::Deserialize;
 use crate::db;
 use crate::error::AppError;
 use crate::models::agent::*;
-use crate::models::agent_equip::{AgentEquipment, CreateEquipmentRequest, UpdateEquipmentRequest};
+use crate::models::agent_equip::{
+    AgentEquipment, CreateEquipmentRequest, Loadout, UpdateEquipmentRequest,
+};
 use crate::services::agent_identity::AgentService;
 use crate::tenant::RequestTenantContext;
 
@@ -384,4 +386,18 @@ pub async fn delete_equipment(
         .delete_equipment(&tenant_ctx.tenant_id, &equip_id)
         .await?;
     Ok(Json(serde_json::json!({ "deleted": deleted })))
+}
+
+/// Resolve the agent's effective loadout (all bound assets, grouped by type).
+/// GET /agents/{agent_id}/loadout
+pub async fn get_loadout(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(agent_id): Path<String>,
+) -> Result<Json<Loadout>, AppError> {
+    let pool = db::pool();
+    let service = AgentService::new(pool.clone());
+    let loadout = service
+        .resolve_loadout(&tenant_ctx.tenant_id, &agent_id)
+        .await?;
+    Ok(Json(loadout))
 }

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -323,6 +323,8 @@ pub fn root() -> Router {
                 .put(agent::update_equipment)
                 .delete(agent::delete_equipment),
         )
+        // Loadout — atomic snapshot of an agent's bound assets (#89)
+        .route("/agents/{agent_id}/loadout", get(agent::get_loadout))
         // Complete agent info
         .route(
             "/agents/{agent_id}/complete",

--- a/backend/src/services/agent_identity.rs
+++ b/backend/src/services/agent_identity.rs
@@ -162,6 +162,40 @@ impl AgentService {
         self.equipment_repo.delete(tenant_id, id).await
     }
 
+    /// Resolve the agent's effective loadout: all bound equipment, grouped by
+    /// asset type (tenant-scoped). Satisfies #89's "agent resolves loadout
+    /// atomically" — one read, one snapshot.
+    pub async fn resolve_loadout(
+        &self,
+        tenant_id: &TenantId,
+        agent_id: &str,
+    ) -> Result<crate::models::agent_equip::Loadout, AppError> {
+        let equipment = self
+            .equipment_repo
+            .list_by_agent(tenant_id, agent_id)
+            .await?;
+        let mut skills = Vec::new();
+        let mut l1_memories = Vec::new();
+        let mut l2_scenes = Vec::new();
+        let mut l3_personas = Vec::new();
+        for eq in equipment {
+            match eq.asset_type.as_str() {
+                "skill" => skills.push(eq),
+                "l1_memory" => l1_memories.push(eq),
+                "l2_scene" => l2_scenes.push(eq),
+                "l3_persona" => l3_personas.push(eq),
+                _ => {} // unknown asset_type — ignore (forward-compat)
+            }
+        }
+        Ok(crate::models::agent_equip::Loadout {
+            agent_id: agent_id.to_string(),
+            skills,
+            l1_memories,
+            l2_scenes,
+            l3_personas,
+        })
+    }
+
     // =========================================================================
     // Episode Operations
     // =========================================================================


### PR DESCRIPTION
## 目标

PR #100 接线了 `agent_equipment` 的 tenant-scoped CRUD，但缺 #89 验收项"agent 启动/任务执行可**原子解析有效 loadout**"。本 PR 加 `Loadout` 结构（按 asset_type 分组的装备快照）+ `AgentService::resolve_loadout`（一次读→分组→快照）+ `GET /agents/{id}/loadout`。

## 变更

- **`models/agent_equip.rs`**：`Loadout { agent_id, skills, l1_memories, l2_scenes, l3_personas }`——首期是 binding 行分组（按 asset_type match）；按 `asset_id` 解析实际资产内容（skill/scene/persona body）是 follow-up（调用方可按 id 从各自端点取）。
- **`services/agent_identity.rs`**：`resolve_loadout`（`list_by_agent` → match `asset_type` 分组）。
- **`routers/agent.rs`**：`get_loadout` handler（`Extension<RequestTenantContext>` tenant-scope）。
- **`routers/mod.rs`**：`GET /agents/{agent_id}/loadout` 路由。

## 设计

- **原子快照**：一次 `list_by_agent` 读 → 内存分组 → 一个 `Loadout`，符合 #89"原子解析"。RLS 兜底（equipment 表已 RLS，#100）。
- **首期是 binding 行**：`Loadout` 各组是 `Vec<AgentEquipment>`（含 `asset_id` + `asset_type` + `binding_type` + `condition` + `priority`），不内联资产内容——避免跨表 join 的复杂度；客户端按需取内容。按 `asset_id` 解析内容是 follow-up。

## 验证

\`\`\`bash
cd backend
cargo check --all-targets  # 0 error
cargo test --lib           # 433 passed / 0 failed
\`\`\`

手动（PG + JWT）：`POST /api/v1/agents/x/equipment` 加几条不同 asset_type → `GET /api/v1/agents/x/loadout` → `{skills:[...], l1_memories:[...], ...}` 分组快照。

## 验收对照 (#89)

- [x] Agent 启动/任务执行可原子解析有效 loadout —— 本 PR（resolve_loadout，一次读分组）。
- [ ] Loadout 解析实际资产内容（skill/scene/persona body）—— follow-up。
- [ ] private 资产默认仅 owner 可见 —— follow-up（需 Visibility + ACL）。
- [ ] 应用层 ACL ↔ DB RLS 一致性测试 —— RLS 阻跨租户；完整测试 follow-up。

## follow-up（独立 PR）

按 `asset_id` 解析实际资产内容（join skills/scenes/personas）· `Visibility`(Private/Team/Public) + rbac `Permission` ACL · DB 级跨租户/跨团队/撤权一致性测试。