### PR TITLE
feat(metrics): WebSocket 指标——active connections + lagged drops (#86 续作)

### DIFF
--- a/backend/src/protocol/websocket.rs
+++ b/backend/src/protocol/websocket.rs
@@ -448,6 +448,8 @@ async fn handle_ws_connection(
 ) {
     let manager = ws_manager();
     let (session_id, mut broadcast_rx) = manager.create_session(tenant_ctx.clone()).await;
+    crate::services::prometheus_exporter::get_exporter()
+        .set_ws_connections_active(manager.connection_count().await as f64);
 
     // Send the Connected frame so the client knows its session_id.
     let connected = WsMessage {
@@ -466,6 +468,8 @@ async fn handle_ws_connection(
         .is_err()
     {
         manager.remove_session(&session_id).await;
+        crate::services::prometheus_exporter::get_exporter()
+            .set_ws_connections_active(manager.connection_count().await as f64);
         return;
     }
 
@@ -534,6 +538,8 @@ async fn handle_ws_connection(
                             skipped = n,
                             "WS client lagged, dropping events"
                         );
+                        crate::services::prometheus_exporter::get_exporter()
+                            .inc_ws_lagged_drops();
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
                 }
@@ -542,6 +548,8 @@ async fn handle_ws_connection(
     }
 
     manager.remove_session(&session_id).await;
+    crate::services::prometheus_exporter::get_exporter()
+        .set_ws_connections_active(manager.connection_count().await as f64);
 }
 
 async fn handle_ws_message(

--- a/backend/src/services/prometheus_exporter.rs
+++ b/backend/src/services/prometheus_exporter.rs
@@ -74,6 +74,10 @@ pub struct PrometheusExporter {
     /// Spill lines skipped during replay because they could not be parsed
     /// (truncated tail from a crash mid-write, or corruption).
     audit_truncated_skipped_total: prometheus::Counter,
+    /// Active WebSocket connections (#86)
+    ws_connections_active: prometheus::Gauge,
+    /// WebSocket events dropped because the client lagged behind the broadcast (#86)
+    ws_lagged_drops_total: prometheus::Counter,
     /// Prometheus registry for metric collection
     registry: prometheus::Registry,
 }
@@ -265,6 +269,18 @@ impl PrometheusExporter {
         )
         .expect("counter creation failed");
 
+        let ws_connections_active = prometheus::Gauge::new(
+            "ws_connections_active",
+            "Number of active WebSocket connections",
+        )
+        .expect("gauge creation failed");
+
+        let ws_lagged_drops_total = prometheus::Counter::new(
+            "ws_lagged_drops_total",
+            "WebSocket events dropped because the client lagged behind the broadcast",
+        )
+        .expect("counter creation failed");
+
         // Register all metrics with the registry
         registry
             .register(Box::new(stm_sessions_active.clone()))
@@ -343,6 +359,12 @@ impl PrometheusExporter {
         registry
             .register(Box::new(audit_truncated_skipped_total.clone()))
             .expect("failed to register audit_truncated_skipped_total");
+        registry
+            .register(Box::new(ws_connections_active.clone()))
+            .expect("failed to register ws_connections_active");
+        registry
+            .register(Box::new(ws_lagged_drops_total.clone()))
+            .expect("failed to register ws_lagged_drops_total");
 
         Self {
             stm_sessions_active,
@@ -370,6 +392,8 @@ impl PrometheusExporter {
             audit_replayed_total,
             audit_dropped_total,
             audit_truncated_skipped_total,
+            ws_connections_active,
+            ws_lagged_drops_total,
             registry,
         }
     }
@@ -444,6 +468,17 @@ impl PrometheusExporter {
     /// Increment outbox dead letter counter
     pub fn inc_outbox_dead_letter(&self) {
         self.outbox_dead_letter_total.inc();
+    }
+
+    /// Set the active WebSocket connection count (#86).
+    pub fn set_ws_connections_active(&self, count: f64) {
+        self.ws_connections_active.set(count);
+    }
+
+    /// Increment when a WS client lagged behind the broadcast and events were
+    /// dropped (#86) — a slow-consumer / backpressure signal.
+    pub fn inc_ws_lagged_drops(&self) {
+        self.ws_lagged_drops_total.inc();
     }
 
     /// Record outbox processing duration
@@ -653,6 +688,20 @@ mod tests {
 
         assert!(output.contains("memory_stm_sessions_active"));
         assert!(output.contains("memory_ltm_entries_total"));
+    }
+
+    #[test]
+    fn test_ws_metrics_registered() {
+        // #86: confirm the WS gauge + counter are registered. Live setter
+        // callers exist in handle_ws_connection (create/remove set the gauge,
+        // Lagged incs the counter) — see aetheris-metrics-mostly-dead.
+        let exporter = PrometheusExporter::new();
+        exporter.set_ws_connections_active(3.0);
+        exporter.inc_ws_lagged_drops();
+
+        let output = exporter.generate_prometheus_output();
+        assert!(output.contains("ws_connections_active"), "missing gauge: {output}");
+        assert!(output.contains("ws_lagged_drops_total"), "missing counter: {output}");
     }
 
     #[test]


### PR DESCRIPTION
## 目标

PR #98 的 WS 首期把指标列了 follow-up（`prometheus_metrics_middleware` 只记 101 握手，不记连接生命周期）。本 PR 注册两个 WS 指标并接到 `WsConnectionManager` 的真实事件，交付 #86 验收「有连接数、丢弃数指标」（部分）。

## 变更

- **`services/prometheus_exporter.rs`**：注册 `ws_connections_active` (gauge) + `ws_lagged_drops_total` (counter) + `set_ws_connections_active`/`inc_ws_lagged_drops` setter + 注册守卫测试。
- **`protocol/websocket.rs`**：`handle_ws_connection` 4 处调用点——create_session 后 set、early-return remove 后 set、`RecvError::Lagged` 时 inc、loop 退出 remove 后 set。

## 设计

- **指标 live**：setter 有真实调用方（websocket.rs 的 create/remove/Lagged），符合 metrics-mostly-dead 规则（注册但不被调用的 metric 是死的）。
- **gauge 取值**：`manager.connection_count()`（读 connections map 大小），create/remove 后调用——连接/disconnect 低频，锁开销可忽略。
- **counter**：Lagged（慢消费者背压）时 inc——直接观测丢弃事件。

## 验证

```bash
cd backend
cargo check --all-targets   # 0 error
cargo test --lib             # 434 passed / 0 failed（含新增 test_ws_metrics_registered）
```

`test_ws_metrics_registered`：断言 `generate_prometheus_output()` 含 `ws_connections_active` + `ws_lagged_drops_total`（注册守卫）。手动：`GET /metrics` 可见这两个指标。

## 验收对照 (#86)

- [x] 有连接数、丢弃数指标 —— 本 PR（active connections gauge + lagged drops counter）。
- [ ] 队列深度、发送延迟指标 —— follow-up（per-conn 队列深度 gauge + 发送延迟 histogram）。
- [ ] 双会话隔离/断线重连/慢消费者集成测试 —— follow-up（需 tokio-tungstenite harness）。

## follow-up（独立 PR）

per-connection 队列深度 gauge · 发送延迟 histogram · WS 客户端集成测试。