### PR TITLE
fix(db): distillation 读查询加 TIMESTAMPTZ→text cast——修运行时解码失败

### DIFF
--- a/backend/src/db/distillation.rs
+++ b/backend/src/db/distillation.rs
@@ -74,7 +74,7 @@ impl DistillationRepository {
 
         // Build dynamic query based on filters
         let mut query = String::from(
-            "SELECT * FROM distillation_atoms WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND is_active = TRUE",
+            "SELECT id, tenant_id, user_id, agent_id, atom_type, scene_name, content, priority, source_session_id, source_message_ids, metadata, embedding_model, embedding_dimension, is_active, superseded_by, created_at::text, updated_at::text FROM distillation_atoms WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND is_active = TRUE",
         );
         let mut param_idx = 4;
 
@@ -116,7 +116,7 @@ impl DistillationRepository {
     pub async fn get_atom(id: &str, tenant_id: &TenantId) -> Result<Option<L1Atom>, AppError> {
         let pool = pool();
         sqlx::query_as::<_, L1Atom>(
-            "SELECT * FROM distillation_atoms WHERE id = $1 AND tenant_id = $2",
+            "SELECT id, tenant_id, user_id, agent_id, atom_type, scene_name, content, priority, source_session_id, source_message_ids, metadata, embedding_model, embedding_dimension, is_active, superseded_by, created_at::text, updated_at::text FROM distillation_atoms WHERE id = $1 AND tenant_id = $2",
         )
         .bind(id)
         .bind(tenant_id.as_str())
@@ -175,7 +175,7 @@ impl DistillationRepository {
     ) -> Result<Vec<L1Atom>, AppError> {
         let pool = pool();
         sqlx::query_as::<_, L1Atom>(
-            "SELECT * FROM distillation_atoms WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND scene_name = $4 AND is_active = TRUE ORDER BY priority DESC, created_at ASC",
+            "SELECT id, tenant_id, user_id, agent_id, atom_type, scene_name, content, priority, source_session_id, source_message_ids, metadata, embedding_model, embedding_dimension, is_active, superseded_by, created_at::text, updated_at::text FROM distillation_atoms WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 AND scene_name = $4 AND is_active = TRUE ORDER BY priority DESC, created_at ASC",
         )
         .bind(tenant_id.as_str())
         .bind(user_id)
@@ -241,7 +241,7 @@ impl DistillationRepository {
     ) -> Result<Vec<L2Scene>, AppError> {
         let pool = pool();
         sqlx::query_as::<_, L2Scene>(
-            "SELECT * FROM distillation_scenes WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 ORDER BY updated_at DESC",
+            "SELECT id, tenant_id, user_id, agent_id, scene_name, title, content, atom_ids, version, token_count, created_at::text, updated_at::text FROM distillation_scenes WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3 ORDER BY updated_at DESC",
         )
         .bind(tenant_id.as_str())
         .bind(user_id)
@@ -257,7 +257,7 @@ impl DistillationRepository {
     pub async fn get_scene(id: &str, tenant_id: &TenantId) -> Result<Option<L2Scene>, AppError> {
         let pool = pool();
         sqlx::query_as::<_, L2Scene>(
-            "SELECT * FROM distillation_scenes WHERE id = $1 AND tenant_id = $2",
+            "SELECT id, tenant_id, user_id, agent_id, scene_name, title, content, atom_ids, version, token_count, created_at::text, updated_at::text FROM distillation_scenes WHERE id = $1 AND tenant_id = $2",
         )
         .bind(id)
         .bind(tenant_id.as_str())
@@ -317,7 +317,7 @@ impl DistillationRepository {
     ) -> Result<Option<L3Persona>, AppError> {
         let pool = pool();
         sqlx::query_as::<_, L3Persona>(
-            "SELECT * FROM distillation_personas WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3",
+            "SELECT id, tenant_id, user_id, agent_id, profile_content, scene_ids, version, token_count, created_at::text, updated_at::text FROM distillation_personas WHERE tenant_id = $1 AND user_id = $2 AND agent_id = $3",
         )
         .bind(tenant_id.as_str())
         .bind(user_id)
@@ -433,7 +433,7 @@ impl DistillationRepository {
         let pool = pool();
         let query = if let Some(s) = status {
             sqlx::query_as::<_, DistillationJob>(
-                "SELECT * FROM distillation_jobs WHERE tenant_id = $1 AND status = $2 ORDER BY created_at DESC LIMIT $3 OFFSET $4",
+                "SELECT id, tenant_id, user_id, agent_id, session_id, job_type, status, error_message, atoms_created, started_at::text, completed_at::text, created_at::text FROM distillation_jobs WHERE tenant_id = $1 AND status = $2 ORDER BY created_at DESC LIMIT $3 OFFSET $4",
             )
             .bind(tenant_id.as_str())
             .bind(s)
@@ -443,7 +443,7 @@ impl DistillationRepository {
             .await
         } else {
             sqlx::query_as::<_, DistillationJob>(
-                "SELECT * FROM distillation_jobs WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
+                "SELECT id, tenant_id, user_id, agent_id, session_id, job_type, status, error_message, atoms_created, started_at::text, completed_at::text, created_at::text FROM distillation_jobs WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
             )
             .bind(tenant_id.as_str())
             .bind(limit)


### PR DESCRIPTION
## 目标

发现一个**潜在运行时 bug**：`db/distillation.rs` 的 8 处读查询用 `SELECT *`，但 PG distillation 表的 `created_at`/`updated_at`（jobs 还有 `started_at`/`completed_at`）是 **TIMESTAMPTZ**，而 Rust model（`L1Atom`/`L2Scene`/`L3Persona`/`DistillationJob`）这些字段是 `String`。sqlx 无法把 TIMESTAMPTZ 解码成 `String`（`db/stm.rs` 之所以用 `created_at::text` 正是为此）——导致 `/v1/distillation/*` 路由 + #101/#102 的 L2/L3 整合**在运行时对 PG 全部 500**（之前无 PG 测试未暴露）。

## 变更

把 8 处 `SELECT *` 换成**显式列 + `::text` cast**：
- atoms（list_atoms/get_atom/get_atoms_for_scene）：`...created_at::text, updated_at::text`
- scenes（list_scenes/get_scene）：`...created_at::text, updated_at::text`
- personas（get_persona）：`...created_at::text, updated_at::text`
- jobs（list_jobs ×2）：`...started_at::text, completed_at::text, created_at::text`

对齐 `db/stm.rs`/`db/agent_equip.rs`/`db/skill.rs` 范式。**model/API 契约不变**（字段仍 `String`）。

## 影响面

解锁以下在 PG 上的运行时（此前会 500）：
- distillation router：`/v1/distillation/atoms|scenes|persona|jobs` 读。
- #101 L2 整合：`get_atoms_for_scene` + `list_scenes`。
- #102 L3 persona：`list_scenes` + `get_persona`。

## 为什么是潜在 bug（未触发）

CI/test 无 PG（`cargo test --lib` 跑 SQLite/单元测试），distillation 子系统的 PG 路径从未在测试中跑过——所以 `SELECT *` 的解码失败从未暴露。本 PR 在为 #84 recall port（会用 `get_persona`/`list_scenes`）扫清障碍时发现并修复。

## 验证

```bash
cd backend
cargo check --all-targets   # 0 error
cargo test --lib            # 434 passed / 0 failed
```

运行时验证需 PG + 迁移——**follow-up**：补 distillation 的 PG 集成测试（Testcontainers 或针对 PG 的 `query_as` 解码断言）。

## follow-up

distillation PG 集成测试 · #84 recall port（现在 repo 读修好了，可移植 AutoRecallService 到 PG + 加 search_atoms_by_content + 路由）。