### PR TITLE
feat(api): skill 版本发布——version+1 active + 旧版 deprecated（#90 续作）

### DIFF
--- a/backend/src/db/skill.rs
+++ b/backend/src/db/skill.rs
@@ -8,7 +8,7 @@
 
 use crate::db::tenant_scope::begin_tenant_tx;
 use crate::error::AppError;
-use crate::models::skill::{CreateSkillRequest, Skill, UpdateSkillRequest};
+use crate::models::skill::{CreateSkillRequest, PublishSkillRequest, Skill, UpdateSkillRequest};
 use crate::tenant::TenantId;
 use sqlx::PgPool;
 use ulid::Ulid;
@@ -167,5 +167,102 @@ impl SkillRepository {
             .await
             .map_err(|e| AppError::Internal(format!("Failed to commit skill: {e}")))?;
         Ok(affected > 0)
+    }
+
+    /// Publish a new version of a skill (#90): insert a new row with
+    /// `version = max(tenant, name) + 1` and `status = 'active'`, carry over
+    /// name / owner_agent_id / visibility / source_session_ids from the old
+    /// version (plus any content fields the request omits), and mark the old
+    /// row `deprecated`. History is preserved (old rows are immutable). All
+    /// in one tenant-scoped transaction.
+    pub async fn publish_version(
+        &self,
+        tenant_id: &TenantId,
+        id: &str,
+        req: PublishSkillRequest,
+    ) -> Result<String, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+
+        // 1. Load the existing skill (for name + fields to carry over).
+        let existing = sqlx::query_as::<_, Skill>(
+            r#"
+            SELECT id, tenant_id, name, description, version, trigger_conditions,
+                   execution_steps, validation_rules, source_session_ids,
+                   owner_agent_id, visibility, status, embedding_model,
+                   embedding_dimension, created_at::text, updated_at::text
+            FROM skills WHERE tenant_id = $1 AND id = $2
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to load skill: {e}")))?
+        .ok_or_else(|| AppError::NotFound("skill not found".to_string()))?;
+
+        // 2. Next version = max version for (tenant, name) + 1.
+        let (max_version,): (i32,) = sqlx::query_as(
+            "SELECT COALESCE(MAX(version), 0) FROM skills WHERE tenant_id = $1 AND name = $2",
+        )
+        .bind(tenant_id.as_str())
+        .bind(&existing.name)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to get max skill version: {e}")))?;
+
+        // 3. Build the new row's content (carry over fields the request omits).
+        let triggers = match req.trigger_conditions {
+            Some(v) => serde_json::to_value(&v).unwrap_or_default(),
+            None => existing.trigger_conditions.clone(),
+        };
+        let steps = match req.execution_steps {
+            Some(v) => serde_json::to_value(&v).unwrap_or_default(),
+            None => existing.execution_steps.clone(),
+        };
+        let rules = match req.validation_rules {
+            Some(v) => serde_json::to_value(&v).unwrap_or_default(),
+            None => existing.validation_rules.clone(),
+        };
+        let description = req.description.unwrap_or_else(|| existing.description.clone());
+
+        let new_id = Ulid::new().to_string();
+        sqlx::query(
+            r#"
+            INSERT INTO skills
+                (id, tenant_id, name, description, version, trigger_conditions,
+                 execution_steps, validation_rules, source_session_ids,
+                 owner_agent_id, visibility, status)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'active')
+            "#,
+        )
+        .bind(&new_id)
+        .bind(tenant_id.as_str())
+        .bind(&existing.name)
+        .bind(&description)
+        .bind(max_version + 1)
+        .bind(&triggers)
+        .bind(&steps)
+        .bind(&rules)
+        .bind(&existing.source_session_ids)
+        .bind(&existing.owner_agent_id)
+        .bind(&existing.visibility)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to insert new skill version: {e}")))?;
+
+        // 4. Deprecate the old version (history preserved, immutable).
+        sqlx::query(
+            "UPDATE skills SET status = 'deprecated', updated_at = NOW() WHERE tenant_id = $1 AND id = $2",
+        )
+        .bind(tenant_id.as_str())
+        .bind(id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("Failed to deprecate old skill version: {e}")))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Internal(format!("Failed to commit skill publish: {e}")))?;
+        Ok(new_id)
     }
 }

--- a/backend/src/models/skill.rs
+++ b/backend/src/models/skill.rs
@@ -112,3 +112,15 @@ pub struct UpdateSkillRequest {
     pub visibility: Option<Visibility>,
     pub status: Option<SkillStatus>,
 }
+
+/// Publish a new version of an existing skill (#90). Content fields are
+/// optional; omitted ones are carried over from the previous version. The new
+/// row is `active` with `version = max(tenant, name) + 1`; the old row is
+/// marked `deprecated` (history preserved, immutable).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublishSkillRequest {
+    pub description: Option<String>,
+    pub trigger_conditions: Option<Vec<TriggerCondition>>,
+    pub execution_steps: Option<Vec<ExecutionStep>>,
+    pub validation_rules: Option<Vec<ValidationRule>>,
+}

--- a/backend/src/routers/skill.rs
+++ b/backend/src/routers/skill.rs
@@ -16,13 +16,14 @@ use serde::Deserialize;
 use crate::db;
 use crate::db::skill::SkillRepository;
 use crate::error::AppError;
-use crate::models::skill::{CreateSkillRequest, Skill, UpdateSkillRequest};
+use crate::models::skill::{CreateSkillRequest, PublishSkillRequest, Skill, UpdateSkillRequest};
 use crate::tenant::RequestTenantContext;
 
 pub fn router() -> Router {
     Router::new()
         .route("/", get(list_skills).post(create_skill))
         .route("/{id}", get(get_skill).put(update_skill).delete(delete_skill))
+        .route("/{id}/publish", post(publish_skill))
 }
 
 #[derive(Deserialize)]
@@ -95,4 +96,19 @@ pub async fn delete_skill(
     let repo = SkillRepository::new(pool.clone());
     let deleted = repo.delete(&tenant_ctx.tenant_id, &id).await?;
     Ok(Json(serde_json::json!({ "deleted": deleted })))
+}
+
+/// Publish a new version of a skill: new row version+1 `active`, old row
+/// `deprecated` (history preserved, immutable). POST /v1/skills/{id}/publish.
+pub async fn publish_skill(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(id): Path<String>,
+    Json(payload): Json<PublishSkillRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let new_id = repo
+        .publish_version(&tenant_ctx.tenant_id, &id, payload)
+        .await?;
+    Ok(Json(serde_json::json!({ "id": new_id })))
 }

--- a/backend/tests/skill_security.rs
+++ b/backend/tests/skill_security.rs
@@ -84,3 +84,28 @@ async fn create_skill_requires_a_jwt() {
         "unexpected response: {body}"
     );
 }
+
+#[tokio::test]
+async fn publish_skill_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/skills/sk-1/publish")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({}).to_string()))
+                .expect("build publish_skill request"),
+        )
+        .await
+        .expect("serve publish_skill request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}


### PR DESCRIPTION
## 目标

PR #103 的 skill CRUD 只有 draft→active→deprecated 状态切换，缺 #90 验收「Skill 有可审计的**版本**、**版本不可变历史**」。本 PR 加 `publish_version`：一个事务内 load 旧 skill + 取 max(tenant,name) version + 插 version+1 active 新行 + 旧版标 deprecated。

## 变更

- **`models/skill.rs`**：`PublishSkillRequest`（description/triggers/steps/rules 全 Optional，缺省继承旧版本）。
- **`db/skill.rs`**：`publish_version`（`begin_tenant_tx`：load 旧 → max version → insert version+1 `active` 新行，继承 name/owner/visibility/source_session_ids + 请求提供的新内容，缺省继承旧值 → deprecate 旧版；历史不可变）。
- **`routers/skill.rs`**：`POST /v1/skills/{id}/publish` 路由 + `publish_skill` handler（`Extension<RequestTenantContext>` tenant-scope）。
- **`tests/skill_security.rs`**：加 publish 401 auth-gate 测试。

## 设计

- **历史不可变**：旧版行只 `UPDATE status='deprecated'`（不改 content/version）——历史可审计、可回滚到旧 version。新行是新 id + version+1。
- **UNIQUE(tenant_id, name, version)** 保证同 name 的 version 唯一；新行 version = max+1 不冲突。
- **字段继承**：`PublishSkillRequest` 的 Optional 字段缺省继承旧版本的 content（triggers/steps/rules/description）——发布新版本可只改部分。
- **一 tx**：load+max+insert+deprecate 在一个 `begin_tenant_tx` 内（RLS 兜底 + 原子）。

## 验证

```bash
cd backend
cargo check --all-targets      # 0 error
cargo test --lib                # 434 passed / 0 failed
cargo test --test skill_security  # 3 passed（含新 publish 401）
```

手动（PG + JWT）：`POST /v1/skills/{id}/publish` → 新 id（version+1 active）；`GET /v1/skills/{old_id}` → status=deprecated；`GET /v1/skills?status=active` → 新 version。

## 验收对照 (#90)

- [x] Skill 有可审计的版本/发布状态/资源/来源模型 —— version+1 publish（历史不可变）+ status（draft/active/deprecated）+ source_session_ids + owner。
- [ ] 从执行 trace 生成候选 Skill（默认不自动发布）—— follow-up（extractor 存在但未接线）。
- [ ] Wiki / CodeGraph —— 0%，大 follow-up。
- [ ] Loadout 按 ACL 装 Skill —— #89 follow-up。

## follow-up（独立 PR）

从执行 trace 抽候选 Skill（审批后 publish，不自动发布）· Wiki 增量导入 · CodeGraph 查询 · Loadout 按 ACL 装 Skill · 统一/删除 SQLite `services/skill/` 死实现。