### PR TITLE
feat(api): recall port——移植 AutoRecallService 到 PG + /v1/recall（#84 召回半边）

### DIFF
--- a/backend/src/db/distillation.rs
+++ b/backend/src/db/distillation.rs
@@ -189,6 +189,42 @@ impl DistillationRepository {
         })
     }
 
+    /// Keyword search over L1 atoms' content (#84 recall port). Tenant-scoped by
+    /// the `tenant_id` filter (distillation tables have no RLS yet — follow-up).
+    /// Mirrors the SQLite `repository::search_atoms_by_content` (LIKE); a first
+    /// increment — semantic/embedding recall is a follow-up.
+    pub async fn search_atoms_by_content(
+        tenant_id: &TenantId,
+        user_id: &str,
+        query: &str,
+        limit: i64,
+    ) -> Result<Vec<L1Atom>, AppError> {
+        let pool = pool();
+        let pattern = format!("%{}%", query);
+        sqlx::query_as::<_, L1Atom>(
+            r#"
+            SELECT id, tenant_id, user_id, agent_id, atom_type, scene_name, content,
+                   priority, source_session_id, source_message_ids, metadata,
+                   embedding_model, embedding_dimension, is_active, superseded_by,
+                   created_at::text, updated_at::text
+            FROM distillation_atoms
+            WHERE tenant_id = $1 AND user_id = $2 AND content ILIKE $3 AND is_active = TRUE
+            ORDER BY priority DESC
+            LIMIT $4
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(user_id)
+        .bind(&pattern)
+        .bind(limit)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to search atoms by content: {}", e);
+            AppError::Internal(format!("Database error: {}", e))
+        })
+    }
+
     // === L2 Scene operations ===
 
     pub async fn upsert_scene(

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -33,6 +33,7 @@ mod openapi;
 #[allow(dead_code)]
 mod planner;
 mod procedural;
+mod recall;
 mod security;
 mod skill;
 #[allow(dead_code)]
@@ -427,6 +428,8 @@ pub fn root() -> Router {
         )
         // Skill asset routes (#90) — tenant-scoped via RequestTenantContext
         .nest("/v1/skills", skill::router())
+        // Recall — distilled-memory recall over the PG distillation path (#84)
+        .nest("/v1/recall", recall::router())
         // Distillation pipeline routes
         .nest(
             "/v1/distillation",

--- a/backend/src/routers/recall.rs
+++ b/backend/src/routers/recall.rs
@@ -1,0 +1,60 @@
+//! Recall API route — tenant-scoped distilled-memory recall (#84 recall port).
+//!
+//! `POST /v1/recall { query, user_id, agent_id?, strategy?, max_results?,
+//! max_tokens? }` → `RecallResult`. The caller's tenant (from
+//! `RequestTenantContext`) scopes the recall — the body carries **no**
+//! `tenant_id` (never trusted from the client). Recalls L1 atoms (keyword,
+//! PG) + L3 persona + L2 scene navigation from the PG distillation path.
+
+use axum::{extract::Extension, routing::post, Json, Router};
+use serde::Deserialize;
+
+use crate::config;
+use crate::error::AppError;
+use crate::services::recall::{AutoRecallService, RecallRequest, RecallResult, RecallStrategy};
+use crate::tenant::RequestTenantContext;
+
+pub fn router() -> Router {
+    Router::new().route("/", post(recall))
+}
+
+/// Endpoint body — no `tenant_id` (taken from auth). `RecallRequest` is the
+/// internal type that carries the auth-derived tenant_id.
+#[derive(Deserialize)]
+pub struct RecallEndpointRequest {
+    pub query: String,
+    pub user_id: String,
+    pub agent_id: Option<String>,
+    pub strategy: Option<RecallStrategy>,
+    pub max_results: Option<usize>,
+    pub max_tokens: Option<usize>,
+}
+
+pub async fn recall(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Json(req): Json<RecallEndpointRequest>,
+) -> Result<Json<RecallResult>, AppError> {
+    let cfg = config::get();
+    // `max_recall_tokens` isn't a RecallConfig field yet — default 2000.
+    let service = AutoRecallService::new(
+        cfg.recall.timeout_ms,
+        cfg.recall.max_l1_results,
+        2000,
+        cfg.recall.inject_l3_persona,
+        true,
+    );
+    let request = RecallRequest {
+        query: req.query,
+        user_id: req.user_id,
+        agent_id: req.agent_id,
+        tenant_id: tenant_ctx.tenant_id.as_str().to_string(),
+        strategy: req.strategy,
+        max_results: req.max_results,
+        max_tokens: req.max_tokens,
+    };
+    let result = service
+        .recall(&request)
+        .await
+        .map_err(|e| AppError::Internal(format!("recall failed: {e}")))?;
+    Ok(Json(result))
+}

--- a/backend/src/services/recall/auto_recall.rs
+++ b/backend/src/services/recall/auto_recall.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use tracing::{info, warn};
 
-use crate::services::distillation::repository::DistillationRepository;
-use crate::services::distillation::types::{MemoryAtom, MemoryAtomType, Persona, SceneBlock};
+use crate::db::distillation::DistillationRepository;
+use crate::tenant::TenantId;
 
 use super::formatter::RecallFormatter;
 use super::strategy::{RecallSource, RecallStrategy};
@@ -31,14 +31,17 @@ pub struct RecallResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecalledMemory {
     pub content: String,
-    pub atom_type: Option<MemoryAtomType>,
+    /// The distillation atom_type string (e.g. "persona"/"episodic"/"instruction").
+    /// `String` — the PG path stores atom_type as text (the SQLite `MemoryAtomType`
+    /// enum was dropped when AutoRecallService was ported off the SQLite island).
+    pub atom_type: Option<String>,
     pub score: f64,
     pub source: RecallSource,
 }
 
 impl RecalledMemory {
     pub fn atom_type_str(&self) -> &str {
-        self.atom_type.map(|t| t.as_str()).unwrap_or("memory")
+        self.atom_type.as_deref().unwrap_or("memory")
     }
 }
 
@@ -67,21 +70,18 @@ impl AutoRecallService {
         }
     }
 
-    pub async fn recall(
-        &self,
-        pool: &sqlx::Pool<sqlx::Sqlite>,
-        request: &RecallRequest,
-    ) -> Result<RecallResult> {
+    pub async fn recall(&self, request: &RecallRequest) -> Result<RecallResult> {
         let start = Instant::now();
         let strategy = request.strategy.unwrap_or(RecallStrategy::Hybrid);
         let max_results = request.max_results.unwrap_or(self.max_l1_results);
         let max_tokens = request.max_tokens.unwrap_or(self.max_recall_tokens);
 
         let timeout = tokio::time::Duration::from_millis(self.timeout_ms);
-
-        let result = tokio::time::timeout(timeout, self.recall_inner(
-            pool, request, strategy, max_results, max_tokens,
-        )).await;
+        let result = tokio::time::timeout(
+            timeout,
+            self.recall_inner(request, strategy, max_results, max_tokens),
+        )
+        .await;
 
         match result {
             Ok(Ok(mut recall_result)) => {
@@ -111,57 +111,64 @@ impl AutoRecallService {
 
     async fn recall_inner(
         &self,
-        pool: &sqlx::Pool<sqlx::Sqlite>,
         request: &RecallRequest,
         strategy: RecallStrategy,
         max_results: usize,
-        max_tokens: usize,
+        _max_tokens: usize,
     ) -> Result<RecallResult> {
+        let tenant = TenantId::from_string(&request.tenant_id);
         let mut context_memories = Vec::new();
         let mut system_parts = Vec::new();
 
-        // 1. Search L1 atoms by keyword (BM25-like)
+        // 1. Search L1 atoms by keyword (PG distillation path).
         let atoms = DistillationRepository::search_atoms_by_content(
-            pool,
-            &request.tenant_id,
+            &tenant,
             &request.user_id,
             &request.query,
             max_results as i64,
-        ).await.unwrap_or_default();
+        )
+        .await
+        .unwrap_or_default();
 
         for (i, atom) in atoms.iter().enumerate() {
             let score = 1.0 - (i as f64 * 0.1);
             context_memories.push(RecalledMemory {
                 content: atom.content.clone(),
-                atom_type: Some(atom.atom_type),
+                atom_type: Some(atom.atom_type.clone()),
                 score,
                 source: RecallSource::L1Atom,
             });
         }
 
-        // 2. Load L3 persona (stable context)
+        let agent = request.agent_id.as_deref().unwrap_or("");
+
+        // 2. Load L3 persona (stable context).
         if self.inject_persona {
-            if let Ok(Some(persona)) = DistillationRepository::get_persona(
-                pool,
-                &request.tenant_id,
-                &request.user_id,
-                request.agent_id.as_deref(),
-            ).await {
-                let persona_ctx = RecallFormatter::format_persona_context(&persona.content);
+            if let Ok(Some(persona)) =
+                DistillationRepository::get_persona(&tenant, &request.user_id, agent).await
+            {
+                let persona_ctx =
+                    RecallFormatter::format_persona_context(&persona.profile_content);
                 system_parts.push(persona_ctx);
             }
         }
 
-        // 3. Load L2 scene navigation
+        // 3. Load L2 scene navigation.
         if self.inject_scene_nav {
-            let scenes = DistillationRepository::get_scenes_by_user(
-                pool, &request.tenant_id, &request.user_id,
-            ).await.unwrap_or_default();
-
+            let scenes =
+                DistillationRepository::list_scenes(&tenant, &request.user_id, agent)
+                    .await
+                    .unwrap_or_default();
             if !scenes.is_empty() {
-                let nav: Vec<(String, String)> = scenes.iter()
+                let nav: Vec<(String, String)> = scenes
+                    .iter()
                     .take(10)
-                    .map(|s| (s.name.clone(), s.summary.clone()))
+                    .map(|s| {
+                        (
+                            s.scene_name.clone(),
+                            s.content.chars().take(200).collect::<String>(),
+                        )
+                    })
                     .collect();
                 let nav_ctx = RecallFormatter::format_scene_navigation(&nav);
                 system_parts.push(nav_ctx);

--- a/backend/tests/recall_security.rs
+++ b/backend/tests/recall_security.rs
@@ -1,0 +1,53 @@
+//! Security boundary test for `/api/v1/recall` (#84 recall port). Guards the
+//! auth boundary (JWT required). DB-level recall verification needs PG — follow-up.
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header, Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+static CONFIG_INIT: std::sync::Once = std::sync::Once::new();
+
+fn ensure_config() {
+    CONFIG_INIT.call_once(|| {
+        backend::config::init();
+    });
+}
+
+async fn response_json(response: axum::response::Response) -> (StatusCode, Value) {
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let json = serde_json::from_slice(&body).expect("parse JSON response");
+    (status, json)
+}
+
+#[tokio::test]
+async fn recall_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/recall")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "query": "deploy", "user_id": "u" }).to_string(),
+                ))
+                .expect("build recall request"),
+        )
+        .await
+        .expect("serve recall request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}


### PR DESCRIPTION
## 目标

`AutoRecallService` 原本**孤儿 + 读 SQLite distillation**（现已过时 vs PG 路径 L1-L3）。本 PR 移植到 PG + 暴露 `POST /v1/recall`，关闭 #84 闭环的**召回**半边。

## 变更

- **`db/distillation.rs`**：加 `search_atoms_by_content`（PG，keyword `ILIKE`，显式列 + `::text` cast，照 #106 范式）。
- **`services/recall/auto_recall.rs`**：移植到 PG——去 `Sqlite` pool + SQLite 类型（`MemoryAtom`/`MemoryAtomType`/`Persona`/`SceneBlock`），用 PG `DistillationRepository`（`search_atoms_by_content` + `get_persona` + `list_scenes`）；适配类型：`RecalledMemory.atom_type` → `Option<String>`（PG atom_type 是 text）、`persona.profile_content`、`L2Scene.scene_name`+content。
- **`routers/recall.rs`**（新）：`POST /v1/recall` handler（`Extension<RequestTenantContext>`，body 无 `tenant_id`——tenant 从 auth）。
- **`routers/mod.rs`**：`mod recall` + `nest /v1/recall`。
- **`tests/recall_security.rs`**（新）：401 auth-gate。

## 设计

- **PG 为 canonical**：recall 现在读 PG distillation（L1 atoms + L3 persona + L2 scenes），与 distillation 闭环（#99/#101/#102）一致。
- **tenant 从 auth**：endpoint body 无 `tenant_id`；handler 用 `tenant_ctx.tenant_id` 注入 `RecallRequest`。
- **keyword recall（首期）**：`content ILIKE %query%`（照 SQLite 的 LIKE）。语义/embedding recall 是 follow-up（L1 atoms 现无 embedding，需在 L1 加 embedding 生成）。
- **distillation 表无 RLS**：仅 app 层 `WHERE tenant_id=` scope（recall handler 传 auth tenant）。distillation 表加 RLS 是独立 follow-up。

## 闭环状态

#84 采集→提炼→存储→**召回**→注入→反馈：采集→提炼→L2→L3（distillation，#99/#101/#102）+ **召回**（本 PR，POST /v1/recall）。**注入半边**（before_recall 钩子、自动注入到下一轮）仍 open。

## 验证

```bash
cd backend
cargo check --all-targets    # 0 error
cargo test --lib              # 434 passed / 0 failed
cargo test --test recall_security  # 1 passed (401)
```

手动（PG + 迁移 + Ollama + JWT）：触发 STM→LTM transfer → distillation 跑 L0→L1→L2→L3 → `POST /api/v1/recall` {query,user_id,agent_id} → RecallResult（context_memories=匹配的 L1 atoms + system_context=persona+scenes）。

## follow-up（独立 PR）

注入半边（before_recall 钩子、自动注入召回上下文到下一轮）· 语义/embedding recall（L1 atoms 加 embedding）· distillation 表加 RLS + repo 用 begin_tenant_tx · recall 的集成测试。