### PR TITLE
feat(api): skill extractor——从 transcript 抽候选 Skill，不自动发布（#90 续作）

### DIFF
--- a/backend/src/routers/skill.rs
+++ b/backend/src/routers/skill.rs
@@ -24,6 +24,7 @@ pub fn router() -> Router {
         .route("/", get(list_skills).post(create_skill))
         .route("/{id}", get(get_skill).put(update_skill).delete(delete_skill))
         .route("/{id}/publish", post(publish_skill))
+        .route("/extract", post(extract_skills))
 }
 
 #[derive(Deserialize)]
@@ -111,4 +112,26 @@ pub async fn publish_skill(
         .publish_version(&tenant_ctx.tenant_id, &id, payload)
         .await?;
     Ok(Json(serde_json::json!({ "id": new_id })))
+}
+
+#[derive(Deserialize)]
+pub struct ExtractSkillsRequest {
+    pub transcript: String,
+    pub reason: Option<String>,
+}
+
+/// Extract Skill candidates from an execution transcript via the LLM (#90).
+/// Candidates are **suggestions only** — NOT auto-published; the caller reviews
+/// them and publishes the chosen ones via `POST /v1/skills`.
+pub async fn extract_skills(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Json(req): Json<ExtractSkillsRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let _ = tenant_ctx; // extraction is LLM-only (no DB); auth gate via route_layer
+    let extractor = crate::services::skill::extractor::SkillExtractor::new();
+    let candidates = extractor
+        .extract_from_transcript(&req.transcript, req.reason.as_deref())
+        .await
+        .map_err(|e| AppError::Internal(format!("skill extraction failed: {e}")))?;
+    Ok(Json(serde_json::to_value(&candidates).unwrap_or(serde_json::json!([]))))
 }

--- a/backend/src/services/skill/extractor.rs
+++ b/backend/src/services/skill/extractor.rs
@@ -3,17 +3,14 @@ use tracing::{info, warn};
 
 use super::types::*;
 
-pub struct SkillExtractor {
-    llm_base_url: String,
-    llm_model: String,
-}
+/// Extract reusable Skill candidates from an execution transcript via the LLM.
+/// Candidates are **suggestions only** — the caller reviews them and publishes
+/// the chosen ones via `POST /v1/skills` (they are NOT auto-published). #90.
+pub struct SkillExtractor;
 
 impl SkillExtractor {
-    pub fn new(llm_base_url: &str, llm_model: &str) -> Self {
-        Self {
-            llm_base_url: llm_base_url.to_string(),
-            llm_model: llm_model.to_string(),
-        }
+    pub fn new() -> Self {
+        Self
     }
 
     pub async fn extract_from_transcript(
@@ -29,45 +26,20 @@ impl SkillExtractor {
             transcript.to_string()
         };
 
-        let response = self.call_llm(system_prompt, &user_prompt).await?;
-        let skills = parse_skill_response(&response)?;
+        // Use the unified LLM service (Ollama + OpenAI-compatible), not a
+        // raw reqwest call — consistent with the distillation L2/L3 ports
+        // (#101/#102) and correct for OpenAI-compatible deployments.
+        let full_prompt = format!("{}\n\n{}", system_prompt, user_prompt);
+        let llm = crate::services::llm::get_llm_service()
+            .map_err(|e| anyhow::anyhow!("LLM service unavailable: {e}"))?;
+        let response = llm
+            .call_llm_public(&full_prompt)
+            .await
+            .map_err(|e| anyhow::anyhow!("Skill extraction LLM call failed: {e}"))?;
 
+        let skills = parse_skill_response(&response)?;
         info!("Extracted {} skill candidates from transcript", skills.len());
         Ok(skills)
-    }
-
-    async fn call_llm(&self, system_prompt: &str, user_prompt: &str) -> Result<String> {
-        let client = reqwest::Client::new();
-        let url = format!("{}/api/generate", self.llm_base_url);
-
-        let full_prompt = format!(
-            "<|system|>\n{}\n<|user|>\n{}\n<|assistant|>",
-            system_prompt, user_prompt
-        );
-
-        let body = serde_json::json!({
-            "model": self.llm_model,
-            "prompt": full_prompt,
-            "stream": false,
-            "options": { "temperature": 0.3, "num_predict": 4096 }
-        });
-
-        let response = client
-            .post(&url)
-            .json(&body)
-            .timeout(std::time::Duration::from_secs(120))
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            return Err(anyhow::anyhow!("Skill extraction LLM call failed"));
-        }
-
-        #[derive(serde::Deserialize)]
-        struct OllamaResponse { response: String }
-
-        let resp: OllamaResponse = response.json().await?;
-        Ok(resp.response)
     }
 }
 

--- a/backend/tests/skill_security.rs
+++ b/backend/tests/skill_security.rs
@@ -109,3 +109,30 @@ async fn publish_skill_requires_a_jwt() {
         "unexpected response: {body}"
     );
 }
+
+#[tokio::test]
+async fn extract_skills_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/skills/extract")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({ "transcript": "user did X then Y" }).to_string(),
+                ))
+                .expect("build extract_skills request"),
+        )
+        .await
+        .expect("serve extract_skills request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "unexpected response: {body}"
+    );
+}


### PR DESCRIPTION
## 目标

`SkillExtractor::extract_from_transcript`（LLM）原本**孤儿 + 用 reqwest 直连 Ollama**（OpenAI 部署会坏）。本 PR 移植 `call_llm`→`LLMService::call_llm_public`（统一 Ollama/OpenAI，与 distillation L2/L3 移植一致）+ 暴露 `POST /v1/skills/extract`。候选是 suggestion，**不自动发布**——交付 #90 验收「从执行 trace 抽取候选 Skill，默认不自动发布」。

## 变更

- **`services/skill/extractor.rs`**：`SkillExtractor` 去 `llm_base_url`/`model` + `call_llm`，用 `LLMService::call_llm_public`；`parse_skill_response` + `SKILL_EXTRACTION_PROMPT` 不变。
- **`routers/skill.rs`**：`POST /v1/skills/extract` 路由 + `ExtractSkillsRequest` DTO + `extract_skills` handler（`Extension<RequestTenantContext>` auth gate，extraction 是 LLM-only 无 DB）。返回候选为 `serde_json::Value`（不引入 SQLite 类型进 router）。
- **`tests/skill_security.rs`**：加 extract 401 auth-gate 测试。

## 设计

- **LLMService（非 reqwest）**：与 distillation L2/L3 移植（#101/#102）一致，统一 Ollama/OpenAI-compatible，OpenAI 部署不会坏。
- **不自动发布**：endpoint 返回候选数组（suggestion），客户端评审后用 `POST /v1/skills` 发布选中的——满足 #90「默认不自动发布」。
- **候选形是 SQLite SkillCreateRequest**（flat strings）vs PG `CreateSkillRequest`（结构化 TriggerCondition/ExecutionStep）——客户端评审时映射；返回 `serde_json::Value` 避免 SQLite 类型进 router。统一候选形是 follow-up（随 SQLite skill 服务清理）。

## 验证

```bash
cd backend
cargo check --all-targets      # 0 error
cargo test --lib                # 434 passed / 0 failed
cargo test --test skill_security  # 4 passed（含新 extract 401）
```

手动（Ollama + JWT）：`POST /api/v1/skills/extract` {`transcript`:`user did X then Y`,`reason`?:`...`} → `[{name,description,trigger_conditions,execution_steps,...}]` 候选数组（不写入 DB）；评审后 `POST /api/v1/skills` 发布选中的。

## 验收对照 (#90)

- [x] 从执行 trace 生成候选 Skill（默认不自动发布）—— 本 PR（extract 端点，候选不写库）。
- [x] Skill 版本/发布状态/资源/来源 —— #103 CRUD + #107 version-publish。
- [ ] 统一候选形到 PG —— follow-up。
- [ ] Wiki / CodeGraph —— 0%，大 follow-up。
- [ ] Loadout 按 ACL 装 Skill —— #89 follow-up。

## follow-up（独立 PR）

统一候选形到 PG · Wiki 增量导入 · CodeGraph 查询 · Loadout 按 ACL 装 Skill · 统一/删除 SQLite `services/skill/` 死实现。