### PR TITLE
feat(metrics): WS 发送延迟 histogram（#86 续作）

### DIFF
--- a/backend/src/protocol/websocket.rs
+++ b/backend/src/protocol/websocket.rs
@@ -460,13 +460,16 @@ async fn handle_ws_connection(
             server_version: env!("CARGO_PKG_VERSION").to_string(),
         }),
     };
-    if socket
+    let send_start = std::time::Instant::now();
+    let send_ok = socket
         .send(Message::Text(
             serde_json::to_string(&connected).unwrap_or_default().into(),
         ))
         .await
-        .is_err()
-    {
+        .is_ok();
+    crate::services::prometheus_exporter::get_exporter()
+        .record_ws_send_duration(send_start.elapsed().as_secs_f64());
+    if !send_ok {
         manager.remove_session(&session_id).await;
         crate::services::prometheus_exporter::get_exporter()
             .set_ws_connections_active(manager.connection_count().await as f64);
@@ -498,11 +501,14 @@ async fn handle_ws_connection(
                                 "error": format!("invalid message: {e}"),
                             }),
                         };
-                        if socket
+                        let send_start = std::time::Instant::now();
+                        let send_ok = socket
                             .send(Message::Text(response.to_string().into()))
                             .await
-                            .is_err()
-                        {
+                            .is_ok();
+                        crate::services::prometheus_exporter::get_exporter()
+                            .record_ws_send_duration(send_start.elapsed().as_secs_f64());
+                        if !send_ok {
                             break;
                         }
                     }
@@ -521,13 +527,16 @@ async fn handle_ws_connection(
                                 request_id: None,
                                 payload: WsPayload::Event(event),
                             };
-                            if socket
+                            let send_start = std::time::Instant::now();
+                            let send_ok = socket
                                 .send(Message::Text(
                                     serde_json::to_string(&msg).unwrap_or_default().into(),
                                 ))
                                 .await
-                                .is_err()
-                            {
+                                .is_ok();
+                            crate::services::prometheus_exporter::get_exporter()
+                                .record_ws_send_duration(send_start.elapsed().as_secs_f64());
+                            if !send_ok {
                                 break;
                             }
                         }

--- a/backend/src/services/prometheus_exporter.rs
+++ b/backend/src/services/prometheus_exporter.rs
@@ -78,6 +78,8 @@ pub struct PrometheusExporter {
     ws_connections_active: prometheus::Gauge,
     /// WebSocket events dropped because the client lagged behind the broadcast (#86)
     ws_lagged_drops_total: prometheus::Counter,
+    /// WebSocket frame send duration histogram (#86) — slow-client / backpressure signal.
+    ws_send_duration_seconds: prometheus::Histogram,
     /// Prometheus registry for metric collection
     registry: prometheus::Registry,
 }
@@ -281,6 +283,15 @@ impl PrometheusExporter {
         )
         .expect("counter creation failed");
 
+        let ws_send_duration_seconds = prometheus::Histogram::with_opts(
+            prometheus::HistogramOpts::new(
+                "ws_send_duration_seconds",
+                "WebSocket frame send duration in seconds (slow-client / backpressure signal)",
+            )
+            .buckets(vec![0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0]),
+        )
+        .expect("histogram creation failed");
+
         // Register all metrics with the registry
         registry
             .register(Box::new(stm_sessions_active.clone()))
@@ -365,6 +376,9 @@ impl PrometheusExporter {
         registry
             .register(Box::new(ws_lagged_drops_total.clone()))
             .expect("failed to register ws_lagged_drops_total");
+        registry
+            .register(Box::new(ws_send_duration_seconds.clone()))
+            .expect("failed to register ws_send_duration_seconds");
 
         Self {
             stm_sessions_active,
@@ -394,6 +408,7 @@ impl PrometheusExporter {
             audit_truncated_skipped_total,
             ws_connections_active,
             ws_lagged_drops_total,
+            ws_send_duration_seconds,
             registry,
         }
     }
@@ -479,6 +494,12 @@ impl PrometheusExporter {
     /// dropped (#86) — a slow-consumer / backpressure signal.
     pub fn inc_ws_lagged_drops(&self) {
         self.ws_lagged_drops_total.inc();
+    }
+
+    /// Record a WebSocket frame send duration (#86) — a climbing p99 means the
+    /// client is slow to drain its socket (backpressure / head-of-line blocking).
+    pub fn record_ws_send_duration(&self, duration_secs: f64) {
+        self.ws_send_duration_seconds.observe(duration_secs);
     }
 
     /// Record outbox processing duration
@@ -698,10 +719,12 @@ mod tests {
         let exporter = PrometheusExporter::new();
         exporter.set_ws_connections_active(3.0);
         exporter.inc_ws_lagged_drops();
+        exporter.record_ws_send_duration(0.005);
 
         let output = exporter.generate_prometheus_output();
         assert!(output.contains("ws_connections_active"), "missing gauge: {output}");
         assert!(output.contains("ws_lagged_drops_total"), "missing counter: {output}");
+        assert!(output.contains("ws_send_duration_seconds"), "missing histogram: {output}");
     }
 
     #[test]


### PR DESCRIPTION
## 目标

PR #105 加了 WS 连接数 gauge + lagged drops counter，缺 #86 验收的**发送延迟指标**。本 PR 加 `ws_send_duration_seconds` histogram，在 3 处 `socket.send` 包计时 observe。

## 变更

- **`prometheus_exporter.rs`**：`ws_send_duration_seconds` histogram（buckets 0.1ms-1s）+ `record_ws_send_duration` setter + `test_ws_metrics_registered` 加断言。
- **`protocol/websocket.rs`**：3 处 `socket.send`（Connected 帧、client-response、event-forward）包 `Instant::now()` + `record_ws_send_duration(elapsed.as_secs_f64())`。

## 设计

- **broadcast 模型无队列深度**：broadcast Receiver 不暴露 per-conn pending count；**Lagged 计数器（#105）已是等价的溢出信号**。真正的队列深度需 per-conn mpsc（deferred）。本 PR 只加可干净取的**发送延迟**。
- **3 个 send 点全覆盖**：Connected 帧（握手后）、client→server 响应、server→client 事件转发——每个 send 都 observe，p99 攀升 = 慢客户端/背压。
- **buckets 0.1ms-1s**：WS send 通常亚毫秒；高值（>10ms）= 慢客户端。

## 验证

```bash
cd backend
cargo check --all-targets   # 0 error
cargo test --lib            # 431 passed / 0 failed
cargo test --lib prometheus_exporter  # 18 passed（含 ws_send_duration_seconds 断言）
```

`test_ws_metrics_registered`：断言 `generate_prometheus_output()` 含 `ws_connections_active` + `ws_lagged_drops_total` + `ws_send_duration_seconds`。

## 验收对照 (#86)

- [x] 有连接数、丢弃数、发送延迟指标 —— #105（连接数 + 丢弃数）+ 本 PR（发送延迟）。
- [ ] 队列深度指标 —— defer（broadcast 无 per-conn depth；需 per-conn mpsc）。
- [ ] 双会话隔离/断线重连/慢消费者集成测试 —— follow-up（需 tokio-tungstenite harness）。

## follow-up（独立 PR）

per-conn mpsc 背压（暴露队列深度）· WS 客户端集成测试。