### PR TITLE
fix(data-io): 收尾 #85 — import 接口拒绝假成功，补充边界验证

### DIFF
--- a/backend/src/routers/data_io.rs
+++ b/backend/src/routers/data_io.rs
@@ -245,6 +245,7 @@ async fn export_as_markdown(
 
 /// Import data request
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ImportRequest {
     /// Data format: "json"
     pub format: String,
@@ -255,6 +256,12 @@ pub struct ImportRequest {
     /// Import mode: "merge" or "replace"
     #[serde(default = "default_import_mode")]
     pub mode: String,
+
+    /// Explicit dry-run: when true, the handler validates input and reports
+    /// what *would* be imported without writing anything. When false, the
+    /// handler attempts to write (currently 501 — not implemented).
+    #[serde(default)]
+    pub dry_run: bool,
 }
 
 fn default_import_mode() -> String {
@@ -262,16 +269,64 @@ fn default_import_mode() -> String {
 }
 
 /// Import data handler
+///
+/// #85: Returns 501 for all requests — real import is not yet implemented.
+/// Dry-run vs real import is distinguished in the response so callers can
+/// programmatically detect the feature's availability.
 async fn import_data(
     _tenant_ctx: RequestTenantContext,
-    Json(_req): Json<ImportRequest>,
+    Json(req): Json<ImportRequest>,
 ) -> impl IntoResponse {
+    // Reject unknown formats early — even in 501 mode, we validate the
+    // contract so callers can tell "format not supported" from "import not
+    // implemented".
+    if req.format != "json" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "supported": false,
+                "dry_run": req.dry_run,
+                "message": format!("Unsupported format: '{}'. Only 'json' is accepted.", req.format),
+            })),
+        );
+    }
+    if req.mode != "merge" && req.mode != "replace" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "supported": false,
+                "dry_run": req.dry_run,
+                "message": format!(
+                    "Unsupported mode: '{}'. Use 'merge' or 'replace'.",
+                    req.mode
+                ),
+            })),
+        );
+    }
+    let data_is_empty = req.data.is_null()
+        || req.data.as_object().map(|o| o.is_empty()).unwrap_or(false)
+        || req.data.as_array().map(|a| a.is_empty()).unwrap_or(false);
+    if data_is_empty {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "success": false,
+                "supported": false,
+                "dry_run": req.dry_run,
+                "message": "Import data is empty. Provide at least one entry.",
+            })),
+        );
+    }
+
     (
         StatusCode::NOT_IMPLEMENTED,
         Json(serde_json::json!({
             "success": false,
             "supported": false,
-            "message": "Data import is not supported. No data was written."
+            "dry_run": req.dry_run,
+            "message": "Data import is not implemented. No data was written.",
         })),
     )
 }

--- a/backend/tests/data_io_security.rs
+++ b/backend/tests/data_io_security.rs
@@ -139,3 +139,230 @@ async fn import_is_explicitly_not_implemented() {
     );
     assert_eq!(body["supported"], false);
 }
+
+// ── #85: import edge cases ──
+
+#[tokio::test]
+async fn import_rejects_empty_data() {
+    let auth = auth_header("data-io-empty");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({"format": "json", "data": {}}).to_string()))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unexpected response: {body}");
+    assert!(body["message"].as_str().unwrap().contains("empty"));
+}
+
+#[tokio::test]
+async fn import_rejects_null_data() {
+    let auth = auth_header("data-io-null");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({"format": "json", "data": null}).to_string()))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unexpected response: {body}");
+    assert!(body["message"].as_str().unwrap().contains("empty"));
+}
+
+#[tokio::test]
+async fn import_rejects_empty_array_data() {
+    let auth = auth_header("data-io-arr-empty");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({"format": "json", "data": []}).to_string()))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unexpected response: {body}");
+    assert!(body["message"].as_str().unwrap().contains("empty"));
+}
+
+#[tokio::test]
+async fn import_rejects_unsupported_format() {
+    let auth = auth_header("data-io-bad-format");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({"format": "yaml", "data": {"some": "data"}}).to_string(),
+                ))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unexpected response: {body}");
+    assert!(body["message"].as_str().unwrap().contains("Unsupported format"));
+}
+
+#[tokio::test]
+async fn import_rejects_unsupported_mode() {
+    let auth = auth_header("data-io-bad-mode");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({"format": "json", "mode": "upsert", "data": {"some": "data"}}).to_string(),
+                ))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "unexpected response: {body}");
+    assert!(body["message"].as_str().unwrap().contains("Unsupported mode"));
+}
+
+#[tokio::test]
+async fn import_rejects_unknown_fields() {
+    let auth = auth_header("data-io-unknown");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({"format": "json", "data": {"k": "v"}, "tenant_id": "other"}).to_string(),
+                ))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let status = response.status();
+    let body_bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let body_text = String::from_utf8_lossy(&body_bytes);
+
+    // axum's Json extractor with deny_unknown_fields returns 422 with a
+    // text/plain body (not JSON) — verify the rejection.
+    assert_eq!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "unexpected status: {status}, body: {body_text}"
+    );
+    assert!(
+        body_text.contains("unknown field"),
+        "body should mention unknown field: {body_text}"
+    );
+}
+
+#[tokio::test]
+async fn import_dry_run_returns_not_implemented_with_flag() {
+    let auth = auth_header("data-io-dry-run");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({"format": "json", "dry_run": true, "data": {"ltm": {"entries": [{"title": "x"}]}}}).to_string(),
+                ))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "unexpected response: {body}");
+    assert_eq!(body["dry_run"], true);
+    assert_eq!(body["success"], false);
+    assert_eq!(body["supported"], false);
+}
+
+#[tokio::test]
+async fn import_returns_not_implemented_for_valid_payload() {
+    let auth = auth_header("data-io-valid");
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/data/import")
+                .header(header::AUTHORIZATION, auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "format": "json",
+                        "mode": "merge",
+                        "data": {
+                            "stm": {"sessions": [{"id": "s1", "messages": [{"role": "user", "content": "hello"}]}]},
+                            "ltm": {"entries": [{"title": "test", "content": "value"}]},
+                            "kg": {"entities": [{"name": "e1", "type": "concept"}]},
+                            "mm": {"entries": [{"id": "m1", "type": "text"}]}
+                        }
+                    })
+                    .to_string(),
+                ))
+                .expect("build import request"),
+        )
+        .await
+        .expect("serve import request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED, "unexpected response: {body}");
+    assert_eq!(body["success"], false);
+    assert_eq!(body["supported"], false);
+    assert!(
+        body["message"].as_str().unwrap().contains("not implemented"),
+        "message should state not implemented: {body}"
+    );
+}


### PR DESCRIPTION
## 概述

收尾 #85：数据导入接口不得返回"占位成功"。

## 变更

### 1. `ImportRequest` 加固
- 添加 `#[serde(deny_unknown_fields)]` 防止字段注入（如 `tenant_id`）
- 新增 `dry_run: bool` 显式字段区分试运行与真实导入

### 2. 输入验证
- 空数据 / null / 空数组 → `400 BadRequest`
- 不支持格式（如 `yaml`）→ `400 BadRequest`
- 不支持模式（如 `upsert`）→ `400 BadRequest`
- 未知字段 → `422 UnprocessableEntity`

### 3. 测试
新增 8 个边界测试覆盖：
- 空数据、null、空数组拒绝
- 不支持格式/模式拒绝
- 未知字段拒绝
- `dry_run=true` 仍返回 501
- 有效 payload 返回 501（非假成功）

Closes #85