### PR TITLE
feat(skill): 收尾 #90 — Skill 质量评估端点与安全测试

### DIFF
--- a/backend/src/routers/skill.rs
+++ b/backend/src/routers/skill.rs
@@ -24,6 +24,7 @@ pub fn router() -> Router {
         .route("/", get(list_skills).post(create_skill))
         .route("/{id}", get(get_skill).put(update_skill).delete(delete_skill))
         .route("/{id}/publish", post(publish_skill))
+        .route("/{id}/quality", post(assess_quality))
         .route("/extract", post(extract_skills))
 }
 
@@ -134,4 +135,56 @@ pub async fn extract_skills(
         .await
         .map_err(|e| AppError::Internal(format!("skill extraction failed: {e}")))?;
     Ok(Json(serde_json::to_value(&candidates).unwrap_or(serde_json::json!([]))))
+}
+
+/// Quality assessment for a skill (#90). Returns a structured score with
+/// individual dimensions so callers can decide whether to publish.
+/// POST /v1/skills/{id}/quality
+#[derive(Deserialize)]
+pub struct AssessQualityRequest {
+    pub transcript: Option<String>,
+}
+
+pub async fn assess_quality(
+    Extension(tenant_ctx): Extension<RequestTenantContext>,
+    Path(id): Path<String>,
+    Json(req): Json<AssessQualityRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let pool = db::pool();
+    let repo = SkillRepository::new(pool.clone());
+    let skill = repo
+        .get(&tenant_ctx.tenant_id, &id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("skill not found".to_string()))?;
+
+    // Quality dimensions computed from the skill's structure.
+    let steps = skill.execution_steps.as_array().map(|a| a.len()).unwrap_or(0);
+    let conditions = skill.trigger_conditions.as_array().map(|a| a.len()).unwrap_or(0);
+    let rules = skill.validation_rules.as_array().map(|a| a.len()).unwrap_or(0);
+    let has_description = !skill.description.is_empty();
+    let version = skill.version;
+
+    // Heuristic quality scores — production would use LLM eval on the
+    // transcript (#92).
+    let completeness = if steps > 0 && has_description { 1.0 } else { 0.5 };
+    let robustness = if rules > 0 { 0.8 } else { 0.0 };
+    let maturity = if version > 1 { 0.9 } else { 0.5 };
+    let overall = (completeness + robustness + maturity) / 3.0;
+
+    Ok(Json(serde_json::json!({
+        "skill_id": id,
+        "version": version,
+        "scores": {
+            "completeness": completeness,
+            "robustness": robustness,
+            "maturity": maturity,
+            "overall": overall
+        },
+        "metrics": {
+            "step_count": steps,
+            "trigger_condition_count": conditions,
+            "validation_rule_count": rules,
+            "has_description": has_description
+        }
+    })))
 }

--- a/backend/tests/skill_security.rs
+++ b/backend/tests/skill_security.rs
@@ -136,3 +136,24 @@ async fn extract_skills_requires_a_jwt() {
         "unexpected response: {body}"
     );
 }
+
+#[tokio::test]
+async fn assess_quality_requires_a_jwt() {
+    ensure_config();
+    let app = backend::axum_routers::create_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/skills/sk-1/quality")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({}).to_string()))
+                .expect("build assess_quality request"),
+        )
+        .await
+        .expect("serve assess_quality request");
+
+    let (status, body) = response_json(response).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "unexpected response: {body}");
+}


### PR DESCRIPTION
## 概述

收尾 #90 Skill 资产的最后增量：添加质量评估端点。

## 已有功能（前 4 个 PR）
- ✅ Skill CRUD（create/list/get/update/delete）
- ✅ 版本发布（draft → active → deprecated）
- ✅ 从 transcript 提取候选 Skill（extractor）
- ✅ RLS 安全隔离

## 本次新增
### 质量评估端点
- `POST /api/v1/skills/{id}/quality` — 结构化质量评分
- 维度：completeness（完备性）、robustness（健壮性）、maturity（成熟度）、overall（综合）
- 指标：step_count、trigger_condition_count、validation_rule_count、has_description

### 安全测试
- `assess_quality_requires_a_jwt` — 验证质量端点认证边界

## 后续
- Wiki 导入/CodeGraph 查询 → 见 #90 后续或新建 issue
- LLM 驱动的质量评估 → 见 #92 benchmark

Closes #90