### PR TITLE
feat(benchmark): 收尾 #92 — Benchmark 端点、质量门禁与 JSON 报告

### DIFF
--- a/backend/src/routers/benchmark.rs
+++ b/backend/src/routers/benchmark.rs
@@ -1,0 +1,123 @@
+//! Benchmark API routes (#92).
+//!
+//! Provides endpoints to run the standard eval suite and retrieve results
+//! as machine-readable JSON. The quality gate endpoint can be used in CI
+//! to fail the build when the benchmark pass rate drops below a threshold.
+
+use axum::{
+    extract::Query,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::services::eval_harness;
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/run", post(run_benchmark))
+        .route("/report", get(get_report))
+        .route("/quality-gate", post(run_quality_gate))
+}
+
+#[derive(Deserialize)]
+pub struct QualityGateQuery {
+    /// Minimum pass rate required (0.0–1.0). Default: 0.5.
+    #[serde(default = "default_threshold")]
+    pub threshold: f64,
+}
+
+fn default_threshold() -> f64 {
+    0.5
+}
+
+/// POST /api/v1/benchmark/run
+///
+/// Run the full benchmark suite and return a JSON report. Cacheable
+/// for CI — the result is deterministic given the same scheduler.
+async fn run_benchmark() -> Result<Json<serde_json::Value>, AppError> {
+    let report = eval_harness::run_benchmark_report().await;
+    Ok(Json(report))
+}
+
+/// GET /api/v1/benchmark/report
+///
+/// Return the latest benchmark report (re-runs each time).
+async fn get_report() -> Result<Json<serde_json::Value>, AppError> {
+    let report = eval_harness::run_benchmark_report().await;
+    Ok(Json(report))
+}
+
+/// POST /api/v1/benchmark/quality-gate?threshold=0.5
+///
+/// Run the suite and fail if pass rate below threshold. Returns 200
+/// with the summary if the gate passes, or 422 with failure details.
+async fn run_quality_gate(
+    Query(q): Query<QualityGateQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    if !(0.0..=1.0).contains(&q.threshold) {
+        return Err(AppError::BadRequest(
+            "threshold must be between 0.0 and 1.0".to_string(),
+        ));
+    }
+    match eval_harness::run_quality_gate(q.threshold).await {
+        Ok(summary) => Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "passed": true,
+                "threshold": q.threshold,
+                "summary": summary
+            })),
+        )),
+        Err((summary, message)) => Ok((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(serde_json::json!({
+                "passed": false,
+                "threshold": q.threshold,
+                "message": message,
+                "summary": summary
+            })),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn benchmark_runner_produces_report() {
+        let report = eval_harness::run_benchmark_report().await;
+        assert_eq!(report["suite"], "standard");
+        assert!(report["summary"]["total"].as_u64().unwrap() >= 3);
+        let results = report["results"].as_array().unwrap();
+        assert_eq!(results.len(), report["summary"]["total"].as_u64().unwrap() as usize);
+    }
+
+    #[tokio::test]
+    async fn quality_gate_with_high_threshold_fails() {
+        let result = eval_harness::run_quality_gate(1.0).await;
+        // The heuristic scheduler may not pass all cases, so a 100% threshold
+        // should almost certainly fail.
+        match result {
+            Err((summary, msg)) => {
+                assert!(summary.total > 0);
+                assert!(msg.contains("below threshold"));
+            }
+            Ok(summary) => {
+                // If all 3 cases somehow pass, that's also valid — just assert
+                // the summary is coherent.
+                assert_eq!(summary.passed + summary.failed, summary.total);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn quality_gate_with_zero_threshold_always_passes() {
+        let result = eval_harness::run_quality_gate(0.0).await;
+        assert!(result.is_ok(), "zero threshold should always pass");
+    }
+}

--- a/backend/src/routers/mod.rs
+++ b/backend/src/routers/mod.rs
@@ -9,6 +9,7 @@ use tower_http::trace::TraceLayer;
 
 mod agent;
 mod auth;
+mod benchmark;
 mod billing;
 mod dashboard;
 mod data_io;
@@ -431,6 +432,7 @@ pub fn root() -> Router {
         // Skill asset routes (#90) — tenant-scoped via RequestTenantContext
         .nest("/v1/skills", skill::router())
         .nest("/v1/proxy", proxy::router())
+        .nest("/v1/benchmark", benchmark::router())
         // Recall — distilled-memory recall over the PG distillation path (#84)
         .nest("/v1/recall", recall::router())
         // Distillation pipeline routes

--- a/backend/src/services/eval_harness.rs
+++ b/backend/src/services/eval_harness.rs
@@ -237,6 +237,65 @@ pub fn build_standard_suite() -> EvalSuite {
     suite
 }
 
+/// Quality gate: minimum pass rate to pass the benchmark (#92).
+/// Runs the suite and returns `Ok(summary)` if the pass rate meets the
+/// threshold, or `Err((summary, message))` otherwise.
+pub async fn run_quality_gate(threshold_pass_rate: f64) -> Result<EvalSummary, (EvalSummary, String)>
+{
+    let mut suite = build_standard_suite();
+    suite.run().await;
+    let summary = suite.summary();
+    if summary.total == 0 {
+        return Err((summary, "no cases executed".to_string()));
+    }
+    let pass_rate = summary.passed as f64 / summary.total as f64;
+    if pass_rate >= threshold_pass_rate {
+        Ok(summary)
+    } else {
+        Err((
+            summary,
+            format!(
+                "benchmark pass rate {:.1}% below threshold {:.1}%",
+                pass_rate * 100.0,
+                threshold_pass_rate * 100.0
+            ),
+        ))
+    }
+}
+
+/// Run the full benchmark suite and return a machine-readable JSON report.
+pub async fn run_benchmark_report() -> serde_json::Value {
+    let mut suite = build_standard_suite();
+    suite.run().await;
+    let summary = suite.summary();
+    serde_json::json!({
+        "suite": suite.name,
+        "timestamp": chrono::Utc::now().to_rfc3339(),
+        "summary": {
+            "total": summary.total,
+            "passed": summary.passed,
+            "failed": summary.failed,
+            "pass_rate": if summary.total > 0 {
+                summary.passed as f64 / summary.total as f64
+            } else {
+                0.0
+            },
+            "avg_efficiency": summary.avg_efficiency,
+            "avg_coherence": summary.avg_coherence
+        },
+        "results": suite.results.iter().map(|r| {
+            serde_json::json!({
+                "test_name": r.test_name,
+                "passed": r.passed,
+                "actual_efficiency": r.actual_efficiency,
+                "actual_coherence": r.actual_coherence,
+                "selected_memory_types": r.selected_memory_types,
+                "duration_ms": r.duration_ms
+            })
+        }).collect::<Vec<_>>()
+    })
+}
+
 /// "simple_text_task" — a low-complexity, text-only conversation.
 ///
 /// Expected strategy: STM as primary memory, no multimodal or graph


### PR DESCRIPTION
## 概述

收尾 #92：建立可复现的 Memory Benchmark 与质量门禁。

## 新增端点

| 方法 | 路径 | 描述 |
|------|------|------|
| POST | `/api/v1/benchmark/run` | 运行标准 benchmark 套件 |
| GET | `/api/v1/benchmark/report` | 获取最新 JSON 报告 |
| POST | `/api/v1/benchmark/quality-gate?threshold=0.5` | CI 质量门禁 |

## 功能

### Benchmark 套件
- 3 个标准 case：simple_text_task、complex_multimodal_task、deep_reasoning_task
- 运行真实 AdaptiveMemoryScheduler（非 placeholder）
- 输出机器可读 JSON 报告（含 suite、timestamp、summary、per-case results）

### 质量门禁
- `run_quality_gate(threshold)` 在 pass rate 低于阈值时返回 `Err`
- API 端点返回 200/422 区分通过/失败
- 可在 CI 中使用：`curl -X POST /api/v1/benchmark/quality-gate?threshold=0.5`

### 测试
- 3 个测试：report 格式验证、高阈值失败、零阈值通过

Closes #92