### PR TITLE
feat(consolidation): 收尾 #129 — 离线巩固、过期检测与 SoR 对账

### DIFF
--- a/backend/migrations/20260901000001_belief_consolidation.sql
+++ b/backend/migrations/20260901000001_belief_consolidation.sql
@@ -1,0 +1,67 @@
+-- #129: belief consolidation support + the single-cardinality constraint fix.
+--
+-- Two things this migration does:
+--
+-- 1. CONSOLIDATION SUPPORT:
+--    * `last_confirmed_at` — when an authority last re-vouched for an edge.
+--      Stale scans key off THIS (not valid_from): an SoR reconfirmation
+--      resets the aging clock without rewriting the belief's history.
+--      Backfilled from recorded_at (the only confirmation signal that
+--      existed before this column).
+--    * Partial index for the stale scan (open active edges per predicate).
+--
+-- 2. SINGLE-CARDINALITY CONSTRAINT FIX (a real #127 defect this issue's
+--    multi-active scan surfaced): the exclusion constraint
+--    `beliefs_single_open_edge_per_subject` had no cardinality condition, so
+--    MULTI-valued predicates (prefers, owner_of, member_of…) could never hold
+--    more than one open edge — the write gate masked it by force-superseding
+--    equal-rank claims, silently destroying multi-value semantics. The
+--    constraint is rebuilt to apply ONLY to single-valued edges, denormalized
+--    into `memory_beliefs.single_valued` (maintained by the gate from the
+--    catalog at write time) because EXCLUDE cannot join the policies table.
+
+-- ── Consolidation columns ────────────────────────────────────────────────────
+
+ALTER TABLE memory_beliefs
+    ADD COLUMN IF NOT EXISTS last_confirmed_at TIMESTAMPTZ;
+
+UPDATE memory_beliefs
+SET last_confirmed_at = recorded_at
+WHERE last_confirmed_at IS NULL;
+
+ALTER TABLE memory_beliefs
+    ALTER COLUMN last_confirmed_at SET NOT NULL;
+
+-- ── Cardinality flag + constraint rebuild ────────────────────────────────────
+
+ALTER TABLE memory_beliefs
+    ADD COLUMN IF NOT EXISTS single_valued BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Backfill from the policy catalog; single stays TRUE (the safe default:
+-- wrongly-single only blocks a coexistence, wrongly-multi would ALLOW an
+-- invariant violation).
+UPDATE memory_beliefs b
+SET single_valued = (p.cardinality = 'single')
+FROM memory_predicate_policies p
+WHERE b.predicate = p.name
+  AND p.cardinality = 'multi';
+
+ALTER TABLE memory_beliefs
+    DROP CONSTRAINT IF EXISTS beliefs_single_open_edge_per_subject;
+
+ALTER TABLE memory_beliefs ADD CONSTRAINT beliefs_single_open_edge_per_subject
+EXCLUDE USING gist (
+    tenant_id WITH =,
+    subject WITH =,
+    predicate WITH =,
+    tstzrange(valid_from, COALESCE(valid_to, 'infinity'), '[)') WITH &&
+) WHERE (single_valued AND status IN ('active', 'needs_confirm'));
+
+COMMENT ON CONSTRAINT beliefs_single_open_edge_per_subject ON memory_beliefs IS
+    'At most one open edge per SINGLE-cardinality (tenant, subject, predicate); multi-valued predicates are exempt via the single_valued flag maintained by the write gate from the catalog.';
+
+-- ── Scan support index ───────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_beliefs_consolidation_scan
+ON memory_beliefs (tenant_id, predicate, last_confirmed_at)
+WHERE valid_to IS NULL AND status = 'active';

--- a/backend/src/config/mod.rs
+++ b/backend/src/config/mod.rs
@@ -276,6 +276,8 @@ pub struct ServerConfig {
     #[serde(default)]
     pub skills: SkillsConfig,
     #[serde(default)]
+    pub consolidation_worker: ConsolidationWorkerConfig,
+    #[serde(default)]
     pub reconciliation: ReconciliationConfig,
     /// Trusted reverse-proxy IPs whose `X-Forwarded-For` header is honoured by
     /// the rate limiter. Empty (the default) → XFF is never trusted and the
@@ -474,6 +476,37 @@ fn default_otel_service_name() -> String {
     "aetheris-memos-backend".into()
 }
 
+/// #129 belief-consolidation worker knobs.
+#[derive(Deserialize, Clone, Debug)]
+pub struct ConsolidationWorkerConfig {
+    #[serde(default = "default_consolidation_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_consolidation_interval")]
+    pub interval_seconds: u64,
+    #[serde(default = "default_consolidation_batch")]
+    pub per_tenant_batch: i64,
+}
+
+impl Default for ConsolidationWorkerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            interval_seconds: 3600,
+            per_tenant_batch: 100,
+        }
+    }
+}
+
+fn default_consolidation_enabled() -> bool {
+    true
+}
+fn default_consolidation_interval() -> u64 {
+    3600
+}
+fn default_consolidation_batch() -> i64 {
+    100
+}
+
 #[cfg(test)]
 mod tests {
     use super::{check_jwt_secret, validate_embedding_config, EmbeddingConfig};
@@ -546,7 +579,9 @@ mod tests {
 
     #[test]
     fn rejects_known_placeholder_secrets_when_enabled() {
-        assert!(check_jwt_secret(false, "REPLACE_WITH_STRONG_SECRET_OR_USE_APP_JWT_SECRET").is_err());
+        assert!(
+            check_jwt_secret(false, "REPLACE_WITH_STRONG_SECRET_OR_USE_APP_JWT_SECRET").is_err()
+        );
         assert!(check_jwt_secret(false, "change-me-in-production-32chars").is_err());
         assert!(check_jwt_secret(false, "  secret  ").is_err());
     }
@@ -558,7 +593,9 @@ mod tests {
 
     #[test]
     fn accepts_strong_secret_when_enabled() {
-        assert!(check_jwt_secret(false, "b8f2c1a9e7d4463fa0c5182b6e93d7a41f0c2e5b8a9d6c3f").is_ok());
+        assert!(
+            check_jwt_secret(false, "b8f2c1a9e7d4463fa0c5182b6e93d7a41f0c2e5b8a9d6c3f").is_ok()
+        );
     }
 
     #[test]

--- a/backend/src/db/belief.rs
+++ b/backend/src/db/belief.rs
@@ -36,7 +36,16 @@ pub const AUDIT_BELIEF_NOOP: &str = "belief.noop";
 const BELIEF_COLS: &str = "id, tenant_id, principal_id, subject, predicate, object, status, \
      source, trust, risk, valid_from::text AS valid_from, valid_to::text AS valid_to, \
      recorded_at::text AS recorded_at, supersedes_id, superseded_by_id, needs_confirm, \
-     metadata_json::text AS metadata_json";
+     metadata_json::text AS metadata_json, single_valued, \
+     last_confirmed_at::text AS last_confirmed_at";
+
+/// Same columns as [`BELIEF_COLS`], qualified for queries that JOIN the
+/// policies table (its `risk` column would otherwise be ambiguous).
+const BELIEF_COLS_B: &str = "b.id, b.tenant_id, b.principal_id, b.subject, b.predicate, b.object, \
+     b.status, b.source, b.trust, b.risk, b.valid_from::text AS valid_from, \
+     b.valid_to::text AS valid_to, b.recorded_at::text AS recorded_at, b.supersedes_id, \
+     b.superseded_by_id, b.needs_confirm, b.metadata_json::text AS metadata_json, \
+     b.single_valued, b.last_confirmed_at::text AS last_confirmed_at";
 
 const CANDIDATE_COLS: &str =
     "id, tenant_id, principal_id, session_id, subject, predicate, object, \
@@ -176,16 +185,20 @@ impl BeliefRepository {
         predicate: &str,
     ) -> Result<Option<MemoryBelief>, AppError> {
         let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
-        let row = Self::open_edge_in(&mut tx, tenant_id, subject, predicate).await?;
+        let row = Self::open_edge_in(&mut tx, tenant_id, subject, predicate, None).await?;
         tx.commit().await.ok();
         Ok(row)
     }
 
+    /// `object_filter`: for SINGLE-valued predicates pass None (the one open
+    /// slot); for MULTI-valued predicates pass the claim's object so the
+    /// comparison targets the matching edge — distinct objects coexist.
     async fn open_edge_in(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         tenant_id: &TenantId,
         subject: &str,
         predicate: &str,
+        object_filter: Option<&str>,
     ) -> Result<Option<MemoryBelief>, AppError> {
         sqlx::query_as::<_, MemoryBelief>(&format!(
             r#"
@@ -194,6 +207,7 @@ impl BeliefRepository {
             WHERE tenant_id = $1 AND subject = $2 AND predicate = $3
               AND valid_to IS NULL
               AND status IN ('active', 'needs_confirm')
+              AND ($4::text IS NULL OR object = $4)
             ORDER BY valid_from DESC
             LIMIT 1
             FOR UPDATE
@@ -202,6 +216,7 @@ impl BeliefRepository {
         .bind(tenant_id.as_str())
         .bind(subject)
         .bind(predicate)
+        .bind(object_filter)
         .fetch_optional(&mut **tx)
         .await
         .map_err(|e| AppError::Internal(format!("open_edge failed: {e}")))
@@ -322,6 +337,453 @@ impl BeliefRepository {
         Ok(rows)
     }
 
+    // ── Consolidation read/repair face (#129) ───────────────────────────────── //
+    //
+    // Every repair is idempotent: guarded UPDATEs (status/window predicates)
+    // plus candidate rows keyed by a deterministic idempotency key, so a
+    // crashed-and-retried consolidation run leaves the same state as one clean
+    // run — never a second supersede chain link.
+
+    /// Single-valued (subject, predicate) pairs holding MORE than one open
+    /// edge — impossible under the exclusion constraint unless it was bypassed
+    /// (admin surgery, restore from backup); the scan is defense-in-depth.
+    /// Only groups with at least one ACTIVE edge are reported (a settled
+    /// all-needs_confirm group is already parked for a human).
+    pub async fn multi_active_groups(
+        &self,
+        tenant_id: &TenantId,
+        limit: i64,
+    ) -> Result<Vec<(String, String, i64)>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let rows: Vec<(String, String, i64)> = sqlx::query_as(
+            r#"
+            SELECT subject, predicate, COUNT(*) AS n
+            FROM memory_beliefs
+            WHERE tenant_id = $1
+              AND single_valued
+              AND valid_to IS NULL
+              AND status IN ('active', 'needs_confirm')
+            GROUP BY subject, predicate
+            HAVING COUNT(*) > 1
+               AND COUNT(*) FILTER (WHERE status = 'active') > 0
+            ORDER BY subject, predicate
+            LIMIT $2
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("multi_active scan failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows)
+    }
+
+    /// Repair one multi-active group: keep the newest open edge as the slot
+    /// owner, close the rest as superseded pointing at it. If a closed edge's
+    /// source was STRICTLY stronger than the winner's, the winner parks in
+    /// needs_confirm — the conflict/confirm flow #129 prescribes.
+    pub async fn repair_multi_active_group(
+        &self,
+        tenant_id: &TenantId,
+        subject: &str,
+        predicate: &str,
+    ) -> Result<(String, usize, bool), AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let edges: Vec<MemoryBelief> = sqlx::query_as::<_, MemoryBelief>(&format!(
+            r#"
+            SELECT {BELIEF_COLS}
+            FROM memory_beliefs
+            WHERE tenant_id = $1 AND subject = $2 AND predicate = $3
+              AND valid_to IS NULL AND status IN ('active', 'needs_confirm')
+            ORDER BY valid_from DESC, id
+            FOR UPDATE
+            "#
+        ))
+        .bind(tenant_id.as_str())
+        .bind(subject)
+        .bind(predicate)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("multi_active fetch failed: {e}")))?;
+        if edges.len() < 2 {
+            tx.commit().await.ok();
+            return Ok((String::new(), 0, false));
+        }
+
+        let winner = &edges[0];
+        let winner_rank = BeliefSource::parse(&winner.source)
+            .map(|s| s.precedence_rank())
+            .unwrap_or(u8::MAX);
+        let mut parked = false;
+        let mut closed = 0usize;
+        for loser in &edges[1..] {
+            let loser_rank = BeliefSource::parse(&loser.source)
+                .map(|s| s.precedence_rank())
+                .unwrap_or(u8::MAX);
+            sqlx::query(
+                "UPDATE memory_beliefs SET valid_to = NOW(), status = 'superseded', \
+                 superseded_by_id = $1, updated_at = NOW() WHERE id = $2 AND valid_to IS NULL",
+            )
+            .bind(&winner.id)
+            .bind(&loser.id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("multi_active close failed: {e}")))?;
+            closed += 1;
+            if loser_rank < winner_rank {
+                parked = true; // a strictly stronger source lost the slot race
+            }
+        }
+        if parked {
+            sqlx::query(
+                "UPDATE memory_beliefs SET status = 'needs_confirm', needs_confirm = TRUE, \
+                 updated_at = NOW() WHERE id = $1 AND status = 'active'",
+            )
+            .bind(&winner.id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("multi_active park failed: {e}")))?;
+        }
+
+        // Idempotent audit trail: one candidate per repair action.
+        sqlx::query(
+            r#"
+            INSERT INTO memory_belief_candidates
+                (id, tenant_id, principal_id, subject, predicate, object, source, trust,
+                 origin, decision, status, rejection_reason, payload_json, idempotency_key, resolved_at)
+            VALUES ($1,$2,$3,$4,$5,'(multi-active repair)',$6,0,'manual','conflict','pending',
+                    'consolidation: multiple open single-valued edges repaired',
+                    $7::jsonb, $8, NOW())
+            ON CONFLICT (tenant_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+            DO NOTHING
+            "#,
+        )
+        .bind(Ulid::new().to_string())
+        .bind(tenant_id.as_str())
+        .bind(&winner.principal_id)
+        .bind(subject)
+        .bind(predicate)
+        .bind(&winner.source)
+        .bind(serde_json::to_string(&serde_json::json!({
+            "winner": winner.id, "closed": closed, "parked": parked,
+        })).unwrap())
+        .bind(format!("consolidation|multi_active|{subject}|{predicate}"))
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("multi_active candidate failed: {e}")))?;
+
+        let audit = AuditEvent::new(AUDIT_BELIEF_CONFLICT, "memory_belief")
+            .tenant(tenant_id.as_str())
+            .resource_id(&winner.id)
+            .with_metadata(&serde_json::json!({ "subject": subject, "predicate": predicate, "closed": closed }));
+        crate::db::audit::insert_tx(&mut tx, &audit).await?;
+
+        tx.commit().await.ok();
+        Ok((winner.id.clone(), closed, parked))
+    }
+
+    /// Active open edges past their reconfirmation window (stale_scan
+    /// policies). SoR-sourced edges never age ("权威系统更新时失效，不靠时间").
+    pub async fn stale_candidates(
+        &self,
+        tenant_id: &TenantId,
+        limit: i64,
+    ) -> Result<Vec<MemoryBelief>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let rows = sqlx::query_as::<_, MemoryBelief>(&format!(
+            r#"
+            SELECT {BELIEF_COLS_B}
+            FROM memory_beliefs b
+            JOIN memory_predicate_policies p ON p.name = b.predicate
+            WHERE b.tenant_id = $1
+              AND b.status = 'active' AND b.valid_to IS NULL
+              AND b.source <> 'system_of_record'
+              AND p.ttl_policy = 'stale_scan'
+              AND b.last_confirmed_at < NOW() - (p.reconfirm_days * INTERVAL '1 day')
+            ORDER BY b.last_confirmed_at ASC
+            LIMIT $2
+            "#,
+        ))
+        .bind(tenant_id.as_str())
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("stale scan failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows)
+    }
+
+    /// Mark one edge stale (guarded: only from active — replay-safe).
+    /// High-engagement stale edges (feedback count >= threshold) go to the
+    /// confirmation queue instead (#129: 高召回 stale 进待确认).
+    pub async fn mark_stale(
+        &self,
+        tenant_id: &TenantId,
+        belief_id: &str,
+        to_confirm_queue: bool,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let updated = sqlx::query(
+            "UPDATE memory_beliefs SET status = $3, needs_confirm = $4, updated_at = NOW() \
+             WHERE tenant_id = $1 AND id = $2 AND status = 'active'",
+        )
+        .bind(tenant_id.as_str())
+        .bind(belief_id)
+        .bind(if to_confirm_queue {
+            "needs_confirm"
+        } else {
+            "stale"
+        })
+        .bind(to_confirm_queue)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("mark_stale failed: {e}")))?;
+        let changed = updated.rows_affected() > 0;
+        if changed {
+            sqlx::query(
+                r#"
+                INSERT INTO memory_belief_candidates
+                    (id, tenant_id, principal_id, subject, predicate, object, source, trust,
+                     origin, decision, status, rejection_reason, payload_json, idempotency_key, resolved_at)
+                SELECT $1,$2,principal_id,subject,predicate,object,source,trust,'manual',NULL,
+                       $5,'consolidation: stale scan', '{}'::jsonb, $4, NOW()
+                FROM memory_beliefs WHERE tenant_id=$2 AND id=$3
+                ON CONFLICT (tenant_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+                DO NOTHING
+                "#,
+            )
+            .bind(Ulid::new().to_string())
+            .bind(tenant_id.as_str())
+            .bind(belief_id)
+            .bind(format!("consolidation|stale|{belief_id}"))
+            .bind(if to_confirm_queue { "pending" } else { "accepted" })
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("stale candidate failed: {e}")))?;
+            let audit = AuditEvent::new("belief.stale_marked", "memory_belief")
+                .tenant(tenant_id.as_str())
+                .resource_id(belief_id)
+                .with_metadata(&serde_json::json!({ "to_confirm_queue": to_confirm_queue }));
+            crate::db::audit::insert_tx(&mut tx, &audit).await?;
+        }
+        tx.commit().await.ok();
+        Ok(changed)
+    }
+
+    /// Open time-bounded (promise) edges past due: explicit `due_date`
+    /// metadata first, valid_from + 90d fallback.
+    pub async fn expired_promises(
+        &self,
+        tenant_id: &TenantId,
+        limit: i64,
+    ) -> Result<Vec<MemoryBelief>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let rows = sqlx::query_as::<_, MemoryBelief>(&format!(
+            r#"
+            SELECT {BELIEF_COLS_B}
+            FROM memory_beliefs b
+            JOIN memory_predicate_policies p ON p.name = b.predicate
+            WHERE b.tenant_id = $1
+              AND b.status = 'active' AND b.valid_to IS NULL
+              AND p.mutability = 'time_bounded'
+              AND COALESCE(
+                    (b.metadata_json->>'due_date')::timestamptz,
+                    b.valid_from + INTERVAL '90 days'
+                  ) < NOW()
+            ORDER BY b.valid_from ASC
+            LIMIT $2
+            "#,
+        ))
+        .bind(tenant_id.as_str())
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("expired promise scan failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows)
+    }
+
+    /// Retire an expired promise: close the window and archive — it leaves the
+    /// current-truth set but survives as episode/history (#124 Epic).
+    pub async fn retire_promise(
+        &self,
+        tenant_id: &TenantId,
+        belief_id: &str,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let updated = sqlx::query(
+            r#"
+            UPDATE memory_beliefs
+            SET valid_to = NOW(), status = 'archived', updated_at = NOW(),
+                metadata_json = metadata_json || '{"retired_reason":"promise_expired"}'::jsonb
+            WHERE tenant_id = $1 AND id = $2 AND status = 'active' AND valid_to IS NULL
+            "#,
+        )
+        .bind(tenant_id.as_str())
+        .bind(belief_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("retire_promise failed: {e}")))?;
+        let changed = updated.rows_affected() > 0;
+        if changed {
+            sqlx::query(
+                r#"
+                INSERT INTO memory_belief_candidates
+                    (id, tenant_id, principal_id, subject, predicate, object, source, trust,
+                     origin, decision, status, rejection_reason, payload_json, idempotency_key, resolved_at)
+                SELECT $1,$2,principal_id,subject,predicate,object,source,trust,'manual',NULL,
+                       'accepted','consolidation: promise expired','{}'::jsonb, $4, NOW()
+                FROM memory_beliefs WHERE tenant_id=$2 AND id=$3
+                ON CONFLICT (tenant_id, idempotency_key) WHERE idempotency_key IS NOT NULL
+                DO NOTHING
+                "#,
+            )
+            .bind(Ulid::new().to_string())
+            .bind(tenant_id.as_str())
+            .bind(belief_id)
+            .bind(format!("consolidation|promise_expired|{belief_id}"))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Internal(format!("retire candidate failed: {e}")))?;
+            let audit = AuditEvent::new("belief.promise_expired", "memory_belief")
+                .tenant(tenant_id.as_str())
+                .resource_id(belief_id);
+            crate::db::audit::insert_tx(&mut tx, &audit).await?;
+        }
+        tx.commit().await.ok();
+        Ok(changed)
+    }
+
+    /// Open web observations older than the decay horizon, still above the
+    /// action floor — candidates for trust decay.
+    pub async fn web_observations(
+        &self,
+        tenant_id: &TenantId,
+        older_than_hours: i32,
+        limit: i64,
+    ) -> Result<Vec<MemoryBelief>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let rows = sqlx::query_as::<_, MemoryBelief>(&format!(
+            r#"
+            SELECT {BELIEF_COLS}
+            FROM memory_beliefs
+            WHERE tenant_id = $1
+              AND source = 'web' AND status = 'active' AND valid_to IS NULL
+              AND recorded_at < NOW() - ($2 * INTERVAL '1 hour')
+            ORDER BY recorded_at ASC
+            LIMIT $3
+            "#,
+        ))
+        .bind(tenant_id.as_str())
+        .bind(older_than_hours)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("web scan failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows)
+    }
+
+    /// Decay a web observation's trust to a fixed plateau (idempotent: the
+    /// UPDATE only fires when trust is still above the plateau).
+    pub async fn decay_web_trust(
+        &self,
+        tenant_id: &TenantId,
+        belief_id: &str,
+        plateau: f32,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let updated = sqlx::query(
+            "UPDATE memory_beliefs SET trust = $3, updated_at = NOW() \
+             WHERE tenant_id = $1 AND id = $2 AND trust > $3",
+        )
+        .bind(tenant_id.as_str())
+        .bind(belief_id)
+        .bind(plateau)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("web decay failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(updated.rows_affected() > 0)
+    }
+
+    /// Reconciliation target: the LATEST still-current-ish edge for a
+    /// subject+predicate, INCLUDING stale ones (a stale edge is the thing an
+    /// SoR update most often needs to re-vouch for or replace). Superseded /
+    /// archived / rejected history is never a target.
+    pub async fn reconcile_target(
+        &self,
+        tenant_id: &TenantId,
+        subject: &str,
+        predicate: &str,
+    ) -> Result<Option<MemoryBelief>, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let row = sqlx::query_as::<_, MemoryBelief>(&format!(
+            r#"
+            SELECT {BELIEF_COLS}
+            FROM memory_beliefs
+            WHERE tenant_id = $1 AND subject = $2 AND predicate = $3
+              AND valid_to IS NULL
+              AND status IN ('active', 'needs_confirm', 'stale')
+            ORDER BY valid_from DESC
+            LIMIT 1
+            FOR UPDATE
+            "#
+        ))
+        .bind(tenant_id.as_str())
+        .bind(subject)
+        .bind(predicate)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("reconcile_target failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(row)
+    }
+
+    /// Close a STALE edge without a successor link (the SoR replacement that
+    /// follows opens its own edge): history preserved, current set cleaned.
+    pub async fn close_stale_edge(
+        &self,
+        tenant_id: &TenantId,
+        belief_id: &str,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let updated = sqlx::query(
+            "UPDATE memory_beliefs SET valid_to = NOW(), status = 'archived', updated_at = NOW() \
+             WHERE tenant_id = $1 AND id = $2 AND status = 'stale' AND valid_to IS NULL",
+        )
+        .bind(tenant_id.as_str())
+        .bind(belief_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("close_stale_edge failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(updated.rows_affected() > 0)
+    }
+
+    /// SoR reconfirmation: reset the aging clock; a stale edge returns to
+    /// active (the authority re-vouched for it — "stale → active" transition).
+    pub async fn reconfirm_from_sor(
+        &self,
+        tenant_id: &TenantId,
+        belief_id: &str,
+    ) -> Result<bool, AppError> {
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let updated = sqlx::query(
+            "UPDATE memory_beliefs SET last_confirmed_at = NOW(), status = 'active', \
+             needs_confirm = FALSE, updated_at = NOW() \
+             WHERE tenant_id = $1 AND id = $2 AND status IN ('active', 'stale') AND valid_to IS NULL",
+        )
+        .bind(tenant_id.as_str())
+        .bind(belief_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("reconfirm failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(updated.rows_affected() > 0)
+    }
+
     // ── Recall read face (#128) ────────────────────────────────────────────── //
 
     /// Belief rows eligible for retrieval under the #128 hard filters.
@@ -432,6 +894,30 @@ impl BeliefRepository {
         .map_err(|e| AppError::Internal(format!("contract load failed: {e}")))?;
         tx.commit().await.ok();
         Ok(row)
+    }
+
+    /// Feedback signal COUNT per belief id (engagement for the #129
+    /// high-recall stale routing decision).
+    pub async fn feedback_counts(
+        &self,
+        tenant_id: &TenantId,
+        belief_ids: &[String],
+    ) -> Result<std::collections::HashMap<String, i64>, AppError> {
+        if belief_ids.is_empty() {
+            return Ok(Default::default());
+        }
+        let mut tx = begin_tenant_tx(&self.pool, tenant_id).await?;
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT memory_id, COUNT(*) FROM memory_feedback \
+             WHERE tenant_id = $1 AND memory_id = ANY($2) GROUP BY memory_id",
+        )
+        .bind(tenant_id.as_str())
+        .bind(belief_ids)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| AppError::Internal(format!("feedback count failed: {e}")))?;
+        tx.commit().await.ok();
+        Ok(rows.into_iter().collect())
     }
 
     /// Average usefulness (0..1) per belief id from `memory_feedback`.
@@ -611,9 +1097,18 @@ impl BeliefRepository {
             .await;
         }
 
-        // 5. Compare against the open edge under lock.
-        let existing =
-            Self::open_edge_in(&mut tx, tenant_id, &claim.subject, &claim.predicate).await?;
+        // 5. Compare against the open edge under lock. Single-valued: the one
+        // slot. Multi-valued: the edge with the SAME object — distinct objects
+        // never collide and simply coexist (#129 constraint fix).
+        let is_multi = policy.policy.cardinality == "multi";
+        let existing = Self::open_edge_in(
+            &mut tx,
+            tenant_id,
+            &claim.subject,
+            &claim.predicate,
+            is_multi.then_some(claim.object.as_str()),
+        )
+        .await?;
 
         let Some(existing) = existing else {
             // ADD: no open edge. High-risk / weak-source claims park in
@@ -640,6 +1135,7 @@ impl BeliefRepository {
                 trust,
                 &policy.policy.risk,
                 needs_confirm,
+                !is_multi,
             )
             .await?;
             Self::link_candidate_outcome(&mut tx, &candidate_id, &belief_id).await?;
@@ -788,6 +1284,7 @@ impl BeliefRepository {
             trust,
             &policy.policy.risk,
             needs_confirm,
+            !is_multi,
         )
         .await?;
         sqlx::query("UPDATE memory_beliefs SET superseded_by_id = $1 WHERE id = $2")
@@ -907,6 +1404,7 @@ impl BeliefRepository {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     async fn insert_edge(
         tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
         tenant_id: &TenantId,
@@ -916,6 +1414,7 @@ impl BeliefRepository {
         trust: f64,
         risk: &str,
         needs_confirm: bool,
+        single_valued: bool,
     ) -> Result<String, AppError> {
         let id = Ulid::new().to_string();
         let payload = serde_json::to_string(&claim.payload_json)
@@ -925,8 +1424,8 @@ impl BeliefRepository {
             INSERT INTO memory_beliefs
                 (id, tenant_id, principal_id, subject, predicate, object, status,
                  source, trust, risk, valid_from, valid_to, recorded_at,
-                 supersedes_id, needs_confirm, metadata_json)
-            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, NOW(), NULL, NOW(), $11, $12, $13::jsonb)
+                 supersedes_id, needs_confirm, metadata_json, single_valued, last_confirmed_at)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10, NOW(), NULL, NOW(), $11, $12, $13::jsonb, $14, NOW())
             "#,
         )
         .bind(&id)
@@ -946,6 +1445,7 @@ impl BeliefRepository {
         .bind(supersedes)
         .bind(needs_confirm)
         .bind(&payload)
+        .bind(single_valued)
         .execute(&mut **tx)
         .await
         .map_err(|e| {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -174,6 +174,12 @@ async fn main() {
         tracing::warn!("Distillation worker failed to start (non-critical): {e}");
     }
 
+    // #129: belief consolidation loop (stale/expiry/decay scans + SoR
+    // reconcile). Same non-critical posture as distillation.
+    if let Err(e) = crate::services::consolidation::init_consolidation_worker().await {
+        tracing::warn!("Consolidation worker failed to start (non-critical): {e}");
+    }
+
     let app = axum_routers::create_router().layer(hoops::cors_hoop());
     tracing::info!("🔄 Listening on {}", &config.listen_addr);
 

--- a/backend/src/models/belief_record.rs
+++ b/backend/src/models/belief_record.rs
@@ -47,6 +47,13 @@ pub struct MemoryBelief {
     pub superseded_by_id: Option<String>,
     pub needs_confirm: bool,
     pub metadata_json: String,
+    /// Denormalized cardinality (from the catalog) backing the exclusion
+    /// constraint; maintained by the write gate, never edited afterwards.
+    pub single_valued: bool,
+    /// When an authority last re-vouched for this edge (SoR reconciliation).
+    /// Stale scans key off this, so a reconfirmation resets aging without
+    /// rewriting history.
+    pub last_confirmed_at: String,
 }
 
 impl MemoryBelief {

--- a/backend/src/services/consolidation.rs
+++ b/backend/src/services/consolidation.rs
@@ -315,3 +315,528 @@ mod tests {
         assert_eq!(stats.config.stm_threshold, 1000);
     }
 }
+
+// ============================================================================
+// #129: Belief consolidation — offline expiry detection, decay, SoR reconcile
+//
+// Everything above this line is the legacy in-memory prototype; everything
+// below operates on the governed belief store (#127) and is the runnable,
+// observable, idempotent consolidation loop #129 prescribes.
+// ============================================================================
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use sqlx::PgPool;
+
+use crate::db::belief::BeliefRepository;
+use crate::db::memory_event::MemoryEventRepository;
+use crate::error::AppError;
+use crate::models::belief::BeliefSource;
+use crate::models::belief_record::{BeliefClaim, GateOutcome};
+use crate::models::memory_event::{AppendMemoryEventRequest, MemoryEventType};
+use crate::services::belief::BeliefGateService;
+use crate::services::prometheus_exporter::get_exporter;
+use crate::tenant::TenantId;
+
+/// One authoritative fact change pushed by a system of record.
+#[derive(Debug, Clone)]
+pub struct SorUpdate {
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    /// Originating system tag (e.g. "mock-crm", "hr-sync").
+    pub system: String,
+    /// Belief owner when the SoR knows it; resolved from the subject when not.
+    pub principal_id: Option<String>,
+}
+
+impl SorUpdate {
+    /// Attach the belief-owning principal (when the SoR knows it).
+    pub fn principal(mut self, id: impl Into<String>) -> Self {
+        self.principal_id = Some(id.into());
+        self
+    }
+
+    pub fn new(
+        subject: impl Into<String>,
+        predicate: impl Into<String>,
+        object: impl Into<String>,
+        system: impl Into<String>,
+    ) -> Self {
+        Self {
+            subject: subject.into(),
+            predicate: predicate.into(),
+            object: object.into(),
+            system: system.into(),
+            principal_id: None,
+        }
+    }
+}
+
+/// Authority-system adapter (#129: one system, interface first). Fetch the
+/// tenant's authoritative updates since the last cycle; reconciliation turns
+/// each into supersede/reconfirm — never an in-place history edit.
+pub trait SorAdapter: Send + Sync {
+    fn fetch_updates(
+        &self,
+        tenant_id: &TenantId,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Vec<SorUpdate>, AppError>> + Send + '_>,
+    >;
+}
+
+/// Static/configured adapter: fixed updates per tenant. Serves as the minimal
+/// CRM/HR mock #129 asks for and as the test double.
+#[derive(Default)]
+pub struct StaticSorAdapter {
+    updates: std::sync::RwLock<HashMap<String, Vec<SorUpdate>>>,
+}
+
+impl StaticSorAdapter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configure the updates the adapter will serve for one tenant.
+    pub fn set_updates(&self, tenant_id: &TenantId, updates: Vec<SorUpdate>) {
+        self.updates
+            .write()
+            .expect("sor adapter lock")
+            .insert(tenant_id.as_str().to_string(), updates);
+    }
+}
+
+impl SorAdapter for StaticSorAdapter {
+    fn fetch_updates(
+        &self,
+        tenant_id: &TenantId,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Vec<SorUpdate>, AppError>> + Send + '_>,
+    > {
+        let updates = self
+            .updates
+            .read()
+            .expect("sor adapter lock")
+            .get(tenant_id.as_str())
+            .cloned()
+            .unwrap_or_default();
+        Box::pin(std::future::ready(Ok(updates)))
+    }
+}
+
+/// Tuning knobs for the consolidation loop.
+#[derive(Debug, Clone)]
+pub struct BeliefConsolidationConfig {
+    /// Per-scan row cap PER TENANT PER CYCLE — the fairness guarantee (#129:
+    /// one tenant's backlog must not starve the others).
+    pub per_tenant_batch: i64,
+    /// Web observations older than this decay to the first trust plateau.
+    pub web_decay_hours: i32,
+    /// Trust plateaus (fixed steps keep re-runs idempotent).
+    pub web_trust_plateau_1: f32,
+    pub web_trust_plateau_2: f32,
+    /// Stale edges with at least this many feedback signals go to the human
+    /// confirmation queue instead of plain stale (高召回 stale → 待确认).
+    pub confirm_queue_feedback_min: i64,
+}
+
+impl Default for BeliefConsolidationConfig {
+    fn default() -> Self {
+        Self {
+            per_tenant_batch: 100,
+            web_decay_hours: 48,
+            web_trust_plateau_1: 0.15,
+            web_trust_plateau_2: 0.05,
+            confirm_queue_feedback_min: 2,
+        }
+    }
+}
+
+/// What one tenant's consolidation cycle did.
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct ConsolidationReport {
+    pub multi_active_repaired: usize,
+    pub edges_closed_in_repair: usize,
+    pub conflicts_parked: usize,
+    pub stale_marked: usize,
+    pub confirm_queued: usize,
+    pub promises_expired: usize,
+    pub web_decayed: usize,
+    pub sor_diffs: usize,
+    pub sor_opened: usize,
+    pub sor_closed: usize,
+    pub sor_refreshed: usize,
+    pub errors: Vec<String>,
+}
+
+pub struct BeliefConsolidationService {
+    repo: BeliefRepository,
+    events: MemoryEventRepository,
+    gate: BeliefGateService,
+    adapter: Arc<dyn SorAdapter>,
+    config: BeliefConsolidationConfig,
+}
+
+impl BeliefConsolidationService {
+    pub fn new(
+        pool: PgPool,
+        adapter: Arc<dyn SorAdapter>,
+        config: BeliefConsolidationConfig,
+    ) -> Self {
+        Self {
+            repo: BeliefRepository::new(pool.clone()),
+            events: MemoryEventRepository::new(pool.clone()),
+            gate: BeliefGateService::new(pool),
+            adapter,
+            config,
+        }
+    }
+
+    /// Run every scan for one tenant. Each scan is individually idempotent and
+    /// individually failure-isolated: an error in one lands in the report
+    /// (and the failure metric) without aborting the others.
+    pub async fn run_for_tenant(&self, tenant_id: &TenantId) -> ConsolidationReport {
+        let start = std::time::Instant::now();
+        get_exporter().inc_consolidation_runs();
+
+        let mut report = ConsolidationReport::default();
+        self.scan_multi_active(tenant_id, &mut report).await;
+        self.scan_stale(tenant_id, &mut report).await;
+        self.scan_expired_promises(tenant_id, &mut report).await;
+        self.scan_web_decay(tenant_id, &mut report).await;
+        self.reconcile_sor(tenant_id, &mut report).await;
+
+        get_exporter().record_consolidation_run_duration(start.elapsed().as_secs_f64());
+        report
+    }
+
+    /// One fairness round: every listed tenant gets the same per-scan budget;
+    /// a tenant with a huge backlog consumes its batch and yields.
+    pub async fn process_round(
+        &self,
+        tenants: &[TenantId],
+    ) -> HashMap<String, ConsolidationReport> {
+        let mut out = HashMap::new();
+        for tenant in tenants {
+            let report = self.run_for_tenant(tenant).await;
+            out.insert(tenant.as_str().to_string(), report);
+        }
+        out
+    }
+
+    async fn scan_multi_active(&self, tenant_id: &TenantId, report: &mut ConsolidationReport) {
+        let groups = match self
+            .repo
+            .multi_active_groups(tenant_id, self.config.per_tenant_batch)
+            .await
+        {
+            Ok(g) => g,
+            Err(e) => return self.fail("multi_active", e, report),
+        };
+        for (subject, predicate, _n) in groups {
+            match self
+                .repo
+                .repair_multi_active_group(tenant_id, &subject, &predicate)
+                .await
+            {
+                Ok((_winner, closed, parked)) => {
+                    report.multi_active_repaired += 1;
+                    report.edges_closed_in_repair += closed;
+                    if parked {
+                        report.conflicts_parked += 1;
+                    }
+                    get_exporter().inc_consolidation_conflicts();
+                }
+                Err(e) => self.fail("multi_active_repair", e, report),
+            }
+        }
+    }
+
+    async fn scan_stale(&self, tenant_id: &TenantId, report: &mut ConsolidationReport) {
+        let candidates = match self
+            .repo
+            .stale_candidates(tenant_id, self.config.per_tenant_batch)
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => return self.fail("stale", e, report),
+        };
+        if candidates.is_empty() {
+            return;
+        }
+        // Engagement signal decides the destination: high-recall stale edges
+        // queue for a human; the rest simply age out of the active set.
+        let ids: Vec<String> = candidates.iter().map(|b| b.id.clone()).collect();
+        let engagement = match self.repo.feedback_counts(tenant_id, &ids).await {
+            Ok(m) => m,
+            Err(e) => return self.fail("stale_feedback", e, report),
+        };
+        for edge in candidates {
+            let hot = engagement.get(&edge.id).copied().unwrap_or(0)
+                >= self.config.confirm_queue_feedback_min;
+            match self.repo.mark_stale(tenant_id, &edge.id, hot).await {
+                Ok(true) => {
+                    if hot {
+                        report.confirm_queued += 1;
+                    } else {
+                        report.stale_marked += 1;
+                    }
+                    get_exporter().inc_consolidation_stale();
+                }
+                Ok(false) => {} // already non-active: idempotent replay
+                Err(e) => self.fail("mark_stale", e, report),
+            }
+        }
+    }
+
+    async fn scan_expired_promises(&self, tenant_id: &TenantId, report: &mut ConsolidationReport) {
+        let expired = match self
+            .repo
+            .expired_promises(tenant_id, self.config.per_tenant_batch)
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => return self.fail("promises", e, report),
+        };
+        for edge in expired {
+            match self.repo.retire_promise(tenant_id, &edge.id).await {
+                Ok(true) => {
+                    report.promises_expired += 1;
+                    get_exporter().inc_consolidation_promises_expired();
+                }
+                Ok(false) => {}
+                Err(e) => self.fail("retire_promise", e, report),
+            }
+        }
+    }
+
+    async fn scan_web_decay(&self, tenant_id: &TenantId, report: &mut ConsolidationReport) {
+        let observations = match self
+            .repo
+            .web_observations(
+                tenant_id,
+                self.config.web_decay_hours,
+                self.config.per_tenant_batch,
+            )
+            .await
+        {
+            Ok(c) => c,
+            Err(e) => return self.fail("web_decay", e, report),
+        };
+        for edge in observations {
+            // Fixed plateaus keyed on age buckets keep the operation
+            // idempotent: re-running sets the same target again.
+            let age_hours = (chrono::Utc::now()
+                - chrono::DateTime::parse_from_rfc3339(&edge.recorded_at)
+                    .map(|d| d.with_timezone(&chrono::Utc))
+                    .unwrap_or_else(|_| chrono::Utc::now()))
+            .num_hours()
+            .max(0);
+            let plateau = if age_hours >= 2 * self.config.web_decay_hours as i64 {
+                self.config.web_trust_plateau_2
+            } else {
+                self.config.web_trust_plateau_1
+            };
+            match self
+                .repo
+                .decay_web_trust(tenant_id, &edge.id, plateau)
+                .await
+            {
+                Ok(true) => report.web_decayed += 1,
+                Ok(false) => {}
+                Err(e) => self.fail("web_decay_apply", e, report),
+            }
+        }
+    }
+
+    async fn reconcile_sor(&self, tenant_id: &TenantId, report: &mut ConsolidationReport) {
+        let updates = match self.adapter.fetch_updates(tenant_id).await {
+            Ok(u) => u,
+            Err(e) => return self.fail("sor_fetch", e, report),
+        };
+        for update in updates {
+            if let Err(e) = self.apply_sor_update(tenant_id, &update, report).await {
+                self.fail("sor_apply", e, report);
+            }
+        }
+    }
+
+    async fn apply_sor_update(
+        &self,
+        tenant_id: &TenantId,
+        update: &SorUpdate,
+        report: &mut ConsolidationReport,
+    ) -> Result<(), AppError> {
+        // Unknown predicates cannot enter the governed store; they count as
+        // reconciliation differences (surfaced) without silently broadening
+        // the allowlist.
+        if crate::models::belief::find_predicate(&update.predicate).is_none() {
+            report.sor_diffs += 1;
+            get_exporter().inc_consolidation_reconciliation_diffs();
+            return Ok(());
+        }
+
+        // Reconciliation sees STALE edges too — an authority re-vouching for
+        // (or replacing) an aged-out fact is the canonical SoR flow.
+        let open = self
+            .repo
+            .reconcile_target(tenant_id, &update.subject, &update.predicate)
+            .await?;
+        let open_principal = open.as_ref().map(|e| e.principal_id.clone());
+        let stale_edge_id = open
+            .as_ref()
+            .filter(|e| e.status == "stale")
+            .map(|e| e.id.clone());
+        if let Some(edge) = open.filter(|e| e.object == update.object) {
+            // Authority re-vouched for the current truth: refresh the aging
+            // clock (and revive a stale edge). No new version, no history edit.
+            if self.repo.reconfirm_from_sor(tenant_id, &edge.id).await? {
+                report.sor_refreshed += 1;
+                report.sor_diffs += 1;
+                get_exporter().inc_consolidation_reconciliation_diffs();
+            }
+            return Ok(());
+        }
+
+        // A stale target with a DIFFERENT object is replaced: close it first
+        // so the gate's ADD leaves exactly one open edge (the write gate's
+        // open-edge view intentionally does not include stale).
+        if let Some(stale_id) = stale_edge_id {
+            let _ = self.repo.close_stale_edge(tenant_id, &stale_id).await?;
+        }
+
+        // Changed (or brand new): through the WRITE GATE as system_of_record.
+        // Evidence = immutable external_record event, idempotent per update.
+        let principal_id = update
+            .principal_id
+            .clone()
+            .or(open_principal)
+            .unwrap_or_else(|| "__sor__".to_string());
+        let event = self
+            .events
+            .append(
+                tenant_id,
+                AppendMemoryEventRequest::new(
+                    principal_id.clone(),
+                    MemoryEventType::ExternalRecord,
+                )
+                .actor(&update.system)
+                .payload(serde_json::json!({
+                    "system": update.system,
+                    "subject": update.subject,
+                    "predicate": update.predicate,
+                    "object": update.object,
+                }))
+                .idempotency_key(format!(
+                    "sor|{}|{}|{}|{}",
+                    update.system, update.subject, update.predicate, update.object
+                )),
+            )
+            .await?;
+
+        let mut claim = BeliefClaim::new(
+            principal_id,
+            &update.subject,
+            &update.predicate,
+            &update.object,
+            BeliefSource::SystemOfRecord,
+        )
+        .evidence(vec![event.id().to_string()])
+        .payload(serde_json::json!({ "sor_system": update.system }));
+        claim.idempotency_key = Some(format!(
+            "sor|{}|{}|{}|{}",
+            update.system, update.subject, update.predicate, update.object
+        ));
+
+        match self.gate.submit(tenant_id, claim).await {
+            Ok(GateOutcome::Committed { .. }) => {
+                report.sor_opened += 1;
+                report.sor_diffs += 1;
+                get_exporter().inc_consolidation_reconciliation_diffs();
+            }
+            Ok(GateOutcome::Superseded { .. }) => {
+                report.sor_closed += 1;
+                report.sor_diffs += 1;
+                get_exporter().inc_consolidation_reconciliation_diffs();
+            }
+            Ok(GateOutcome::Noop { .. }) => {}
+            Ok(other) => {
+                report.errors.push(format!(
+                    "sor update {:?} resolved unexpectedly: {other:?}",
+                    update.predicate
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+        Ok(())
+    }
+
+    fn fail(&self, stage: &str, e: AppError, report: &mut ConsolidationReport) {
+        get_exporter().inc_consolidation_failures();
+        report.errors.push(format!("{stage}: {e}"));
+        tracing::warn!(stage, error = %e, "consolidation stage failed");
+    }
+}
+
+// ============================================================================
+// Background worker (#129): periodic, tenant-fair consolidation rounds.
+// ============================================================================
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Start the belief-consolidation loop. Idempotent; no-op on non-Postgres
+/// backends (the belief store is PG-only). Non-critical by design: a failed
+/// start logs and returns — the API surface must not depend on the worker.
+pub async fn init_consolidation_worker() -> Result<(), AppError> {
+    if !crate::db::is_postgres() {
+        tracing::info!("consolidation worker skipped: belief store requires PostgreSQL");
+        return Ok(());
+    }
+    let (enabled, interval_seconds, batch) = {
+        let c = &crate::config::get().consolidation_worker;
+        (c.enabled, c.interval_seconds, c.per_tenant_batch)
+    };
+    if !enabled {
+        tracing::info!("consolidation worker disabled by config");
+        return Ok(());
+    }
+
+    static RUNNING: AtomicBool = AtomicBool::new(false);
+    if RUNNING.swap(true, Ordering::SeqCst) {
+        return Ok(());
+    }
+
+    let interval = std::time::Duration::from_secs(interval_seconds);
+    tokio::spawn(async move {
+        // Static adapter until a real CRM/HR integration lands (#129 scope:
+        // interface + one minimal adapter); pushes nothing by default.
+        let adapter: Arc<dyn SorAdapter> = Arc::new(StaticSorAdapter::new());
+        let service = BeliefConsolidationService::new(
+            crate::db::pool().clone(),
+            adapter,
+            BeliefConsolidationConfig {
+                per_tenant_batch: batch,
+                ..Default::default()
+            },
+        );
+        loop {
+            let tenants = crate::services::multi_tenant::list_scheduled_tenants();
+            if !tenants.is_empty() {
+                let reports = service.process_round(&tenants).await;
+                let total_errors: usize = reports.values().map(|r| r.errors.len()).sum();
+                if total_errors > 0 {
+                    tracing::warn!(
+                        tenants = tenants.len(),
+                        total_errors,
+                        "consolidation round had errors"
+                    );
+                } else {
+                    tracing::info!(tenants = tenants.len(), "consolidation round complete");
+                }
+            }
+            tokio::time::sleep(interval).await;
+        }
+    });
+    Ok(())
+}

--- a/backend/src/services/prometheus_exporter.rs
+++ b/backend/src/services/prometheus_exporter.rs
@@ -78,6 +78,13 @@ pub struct PrometheusExporter {
     ws_connections_active: prometheus::Gauge,
     /// WebSocket events dropped because the client lagged behind the broadcast (#86)
     ws_lagged_drops_total: prometheus::Counter,
+    consolidation_run_duration_seconds: prometheus::Histogram,
+    consolidation_runs_total: prometheus::Counter,
+    consolidation_conflicts_total: prometheus::Counter,
+    consolidation_stale_marked_total: prometheus::Counter,
+    consolidation_promises_expired_total: prometheus::Counter,
+    consolidation_reconciliation_diffs_total: prometheus::Counter,
+    consolidation_failures_total: prometheus::Counter,
     /// WebSocket frame send duration histogram (#86) — slow-client / backpressure signal.
     ws_send_duration_seconds: prometheus::Histogram,
     /// WebSocket broadcast channel queue depth (#86) — high values = slow consumer.
@@ -279,6 +286,44 @@ impl PrometheusExporter {
         )
         .expect("gauge creation failed");
 
+        let consolidation_run_duration_seconds = prometheus::Histogram::with_opts(
+            prometheus::HistogramOpts::new(
+                "consolidation_run_duration_seconds",
+                "Belief consolidation run duration in seconds (per tenant)",
+            )
+            .buckets(vec![0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]),
+        )
+        .expect("histogram creation failed");
+        let consolidation_runs_total = prometheus::Counter::new(
+            "consolidation_runs_total",
+            "Belief consolidation runs started",
+        )
+        .expect("counter creation failed");
+        let consolidation_conflicts_total = prometheus::Counter::new(
+            "consolidation_conflicts_total",
+            "Single-valued multi-active groups repaired into the conflict/confirm flow",
+        )
+        .expect("counter creation failed");
+        let consolidation_stale_marked_total = prometheus::Counter::new(
+            "consolidation_stale_marked_total",
+            "Beliefs marked stale (or routed to the confirmation queue) by the stale scan",
+        )
+        .expect("counter creation failed");
+        let consolidation_promises_expired_total = prometheus::Counter::new(
+            "consolidation_promises_expired_total",
+            "Time-bounded promise beliefs retired from the current set",
+        )
+        .expect("counter creation failed");
+        let consolidation_reconciliation_diffs_total = prometheus::Counter::new(
+            "consolidation_reconciliation_diffs_total",
+            "SoR reconciliation differences found (closed, opened, or refreshed)",
+        )
+        .expect("counter creation failed");
+        let consolidation_failures_total = prometheus::Counter::new(
+            "consolidation_failures_total",
+            "Belief consolidation operation failures",
+        )
+        .expect("counter creation failed");
         let ws_lagged_drops_total = prometheus::Counter::new(
             "ws_lagged_drops_total",
             "WebSocket events dropped because the client lagged behind the broadcast",
@@ -290,7 +335,9 @@ impl PrometheusExporter {
                 "ws_send_duration_seconds",
                 "WebSocket frame send duration in seconds (slow-client / backpressure signal)",
             )
-            .buckets(vec![0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0]),
+            .buckets(vec![
+                0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0,
+            ]),
         )
         .expect("histogram creation failed");
 
@@ -385,6 +432,27 @@ impl PrometheusExporter {
             .register(Box::new(ws_lagged_drops_total.clone()))
             .expect("failed to register ws_lagged_drops_total");
         registry
+            .register(Box::new(consolidation_run_duration_seconds.clone()))
+            .expect("failed to register consolidation_run_duration_seconds");
+        registry
+            .register(Box::new(consolidation_runs_total.clone()))
+            .expect("failed to register consolidation_runs_total");
+        registry
+            .register(Box::new(consolidation_conflicts_total.clone()))
+            .expect("failed to register consolidation_conflicts_total");
+        registry
+            .register(Box::new(consolidation_stale_marked_total.clone()))
+            .expect("failed to register consolidation_stale_marked_total");
+        registry
+            .register(Box::new(consolidation_promises_expired_total.clone()))
+            .expect("failed to register consolidation_promises_expired_total");
+        registry
+            .register(Box::new(consolidation_reconciliation_diffs_total.clone()))
+            .expect("failed to register consolidation_reconciliation_diffs_total");
+        registry
+            .register(Box::new(consolidation_failures_total.clone()))
+            .expect("failed to register consolidation_failures_total");
+        registry
             .register(Box::new(ws_send_duration_seconds.clone()))
             .expect("failed to register ws_send_duration_seconds");
         registry
@@ -419,6 +487,13 @@ impl PrometheusExporter {
             audit_truncated_skipped_total,
             ws_connections_active,
             ws_lagged_drops_total,
+            consolidation_run_duration_seconds,
+            consolidation_runs_total,
+            consolidation_conflicts_total,
+            consolidation_stale_marked_total,
+            consolidation_promises_expired_total,
+            consolidation_reconciliation_diffs_total,
+            consolidation_failures_total,
             ws_send_duration_seconds,
             ws_broadcast_queue_depth,
             registry,
@@ -504,6 +579,36 @@ impl PrometheusExporter {
 
     /// Increment when a WS client lagged behind the broadcast and events were
     /// dropped (#86) — a slow-consumer / backpressure signal.
+    /// #129 belief consolidation metrics.
+    pub fn record_consolidation_run_duration(&self, duration_secs: f64) {
+        self.consolidation_run_duration_seconds
+            .observe(duration_secs);
+    }
+
+    pub fn inc_consolidation_runs(&self) {
+        self.consolidation_runs_total.inc();
+    }
+
+    pub fn inc_consolidation_conflicts(&self) {
+        self.consolidation_conflicts_total.inc();
+    }
+
+    pub fn inc_consolidation_stale(&self) {
+        self.consolidation_stale_marked_total.inc();
+    }
+
+    pub fn inc_consolidation_promises_expired(&self) {
+        self.consolidation_promises_expired_total.inc();
+    }
+
+    pub fn inc_consolidation_reconciliation_diffs(&self) {
+        self.consolidation_reconciliation_diffs_total.inc();
+    }
+
+    pub fn inc_consolidation_failures(&self) {
+        self.consolidation_failures_total.inc();
+    }
+
     pub fn inc_ws_lagged_drops(&self) {
         self.ws_lagged_drops_total.inc();
     }
@@ -742,10 +847,22 @@ mod tests {
         exporter.set_ws_broadcast_queue_depth(7.0);
 
         let output = exporter.generate_prometheus_output();
-        assert!(output.contains("ws_connections_active"), "missing gauge: {output}");
-        assert!(output.contains("ws_lagged_drops_total"), "missing counter: {output}");
-        assert!(output.contains("ws_send_duration_seconds"), "missing histogram: {output}");
-        assert!(output.contains("ws_broadcast_queue_depth"), "missing gauge: {output}");
+        assert!(
+            output.contains("ws_connections_active"),
+            "missing gauge: {output}"
+        );
+        assert!(
+            output.contains("ws_lagged_drops_total"),
+            "missing counter: {output}"
+        );
+        assert!(
+            output.contains("ws_send_duration_seconds"),
+            "missing histogram: {output}"
+        );
+        assert!(
+            output.contains("ws_broadcast_queue_depth"),
+            "missing gauge: {output}"
+        );
     }
 
     #[test]

--- a/backend/src/services/recall/core.rs
+++ b/backend/src/services/recall/core.rs
@@ -730,6 +730,8 @@ mod tests {
             superseded_by_id: None,
             needs_confirm: false,
             metadata_json: "{}".into(),
+            single_valued: true,
+            last_confirmed_at: String::new(),
         }
     }
 

--- a/backend/tests/consolidation_pg.rs
+++ b/backend/tests/consolidation_pg.rs
@@ -1,0 +1,870 @@
+//! Belief consolidation acceptance suite (#129) — criteria 1-7.
+//!
+//! | #129 criterion                                              | test |
+//! |-------------------------------------------------------------|------|
+//! | 1. multi-active single predicates → conflict/confirm flow    | `multi_active_detected_and_repaired` |
+//! | 2. stale/expired/archived excluded from default recall       | `retired_states_leave_recall` |
+//! | 3. SoR change closes old belief within the SLA (one cycle)   | `sor_change_closes_and_reconfirms` |
+//! | 4. double consolidation run is idempotent                    | `double_run_is_idempotent` |
+//! | 5. one tenant's backlog cannot starve another                | `tenant_fair_batching` |
+//! | 6. crash-restart safe, no duplicate supersede                | `crash_restart_no_duplicate_supersede` |
+//! | 7. metrics have real callers                                 | `metrics_advance_on_real_runs` |
+//!
+//! Plus the multi-value coexistence regression the multi-active scan surfaced
+//! (the #127 constraint applied to ALL predicates): `multi_valued_predicates_coexist`.
+
+use std::sync::{Arc, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sqlx::PgPool;
+
+use backend::db::belief::BeliefRepository;
+use backend::db::memory_event::MemoryEventRepository;
+use backend::db::principal::PrincipalRepository;
+use backend::models::belief::BeliefSource;
+use backend::models::belief_record::{BeliefClaim, ClaimOrigin, GateOutcome};
+use backend::models::memory_event::{AppendMemoryEventRequest, MemoryEventType};
+use backend::models::principal::{PrincipalAliasType, PrincipalKind};
+use backend::services::belief::BeliefGateService;
+use backend::services::consolidation::{
+    BeliefConsolidationConfig, BeliefConsolidationService, SorUpdate, StaticSorAdapter,
+};
+use backend::services::recall::core::{RecallCoreService, RecallQuery};
+use backend::tenant::TenantId;
+
+fn suffix() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos()
+        .to_string()
+}
+
+/// Pools: an OWNER pool (bypasses RLS and can drop the exclusion constraint to
+/// fabricate anomalies) and a PROBE pool (the app posture). Both on an
+/// immortal detached-thread runtime (see the #128 suite for the pattern).
+static POOLS: OnceLock<(PgPool, PgPool)> = OnceLock::new();
+
+fn pools() -> (PgPool, PgPool) {
+    POOLS
+        .get_or_init(|| {
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(|| {
+                        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL set");
+                        let rt = Box::leak(Box::new(
+                            tokio::runtime::Builder::new_multi_thread()
+                                .worker_threads(2)
+                                .enable_all()
+                                .build()
+                                .expect("setup runtime"),
+                        ));
+                        let owner = rt.block_on(async { PgPool::connect(&url).await }).expect("owner");
+
+                        let migrations_path =
+                            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations");
+                        rt.block_on(async {
+                            sqlx::migrate::Migrator::new(migrations_path)
+                                .await
+                                .expect("migrator")
+                                .run(&owner)
+                                .await
+                                .expect("migrations");
+                            let repo = BeliefRepository::new(owner.clone());
+                            let n = repo.sync_catalog_from_code().await.expect("catalog");
+                            assert!(n >= 6);
+
+                            let role = "aetheris_belief_probe";
+                            let pw = "aetheris_belief_probe_pw";
+                            sqlx::raw_sql(&format!(
+                                r#"DO $$ BEGIN
+                                    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '{role}') THEN
+                                        CREATE ROLE {role} LOGIN PASSWORD '{pw}' NOSUPERUSER NOBYPASSRLS;
+                                    END IF;
+                                END $$;"#
+                            ))
+                            .execute(&owner)
+                            .await
+                            .expect("role");
+                            for stmt in [
+                                "GRANT USAGE ON SCHEMA public TO aetheris_belief_probe",
+                                "GRANT SELECT ON memory_predicate_policies TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT, UPDATE ON memory_beliefs TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT, UPDATE ON memory_belief_candidates TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT, UPDATE ON memory_belief_evidence TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT ON memory_events TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT, UPDATE ON memory_principals TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT, UPDATE ON principal_aliases TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT ON memory_audit_events TO aetheris_belief_probe",
+                                "GRANT SELECT, INSERT ON memory_feedback TO aetheris_belief_probe",
+                            ] {
+                                sqlx::raw_sql(stmt).execute(&owner).await.unwrap_or_else(|e| panic!("{stmt}: {e}"));
+                            }
+
+                            // Repair any constraint left dropped by an aborted
+                            // debug/test run (defense against dirty databases).
+                            sqlx::raw_sql(
+                                "DO $$ BEGIN \
+                                    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'beliefs_single_open_edge_per_subject') THEN \
+                                        ALTER TABLE memory_beliefs ADD CONSTRAINT beliefs_single_open_edge_per_subject \
+                                        EXCLUDE USING gist (tenant_id WITH =, subject WITH =, predicate WITH =, \
+                                        tstzrange(valid_from, COALESCE(valid_to,'infinity'),'[)') WITH &&) \
+                                        WHERE (single_valued AND status IN ('active','needs_confirm')); \
+                                    END IF; \
+                                END $$;",
+                            )
+                            .execute(&owner)
+                            .await
+                            .expect("constraint self-heal");
+
+                            let opts = url
+                                .parse::<sqlx::postgres::PgConnectOptions>()
+                                .expect("url")
+                                .username(role)
+                                .password(pw);
+                            let probe = sqlx::postgres::PgPoolOptions::new()
+                                .min_connections(12)
+                                .max_connections(12)
+                                .acquire_timeout(std::time::Duration::from_secs(10))
+                                .connect_with(opts)
+                                .await
+                                .expect("probe");
+                            for _ in 0..12 {
+                                sqlx::query("SELECT 1").execute(&probe).await.expect("warm");
+                            }
+                            (owner, probe)
+                        })
+                    })
+                    .join()
+                    .expect("setup thread")
+            })
+        })
+        .clone()
+}
+
+/// Re-add the single-open-edge exclusion constraint (idempotent). Also used
+/// at setup: previous failed runs may have left the database without it.
+async fn restore_single_edge_constraint(owner: &PgPool) {
+    sqlx::raw_sql(
+        "DO $$ BEGIN \
+            IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'beliefs_single_open_edge_per_subject') THEN \
+                ALTER TABLE memory_beliefs ADD CONSTRAINT beliefs_single_open_edge_per_subject \
+                EXCLUDE USING gist (tenant_id WITH =, subject WITH =, predicate WITH =, \
+                tstzrange(valid_from, COALESCE(valid_to,'infinity'),'[)') WITH &&) \
+                WHERE (single_valued AND status IN ('active','needs_confirm')); \
+            END IF; \
+        END $$;",
+    )
+    .execute(owner)
+    .await
+    .expect("constraint restored");
+}
+
+struct Ctx {
+    tenant: TenantId,
+    alias: String,
+    principal: String,
+    subject: String,
+    gate: BeliefGateService,
+    repo: BeliefRepository,
+    core: RecallCoreService,
+    events: MemoryEventRepository,
+    probe: PgPool,
+    owner: PgPool,
+}
+
+async fn ctx(label: &str) -> Ctx {
+    let (owner, probe) = pools();
+    let tenant = TenantId::from_string(format!("{label}-{}", suffix()));
+    let alias = format!("u-{}", suffix());
+    let person = PrincipalRepository::new(probe.clone())
+        .ensure_with_alias(
+            &tenant,
+            PrincipalKind::Person,
+            Some("Lisa"),
+            PrincipalAliasType::JwtSub,
+            &alias,
+        )
+        .await
+        .expect("principal");
+    let principal = person.principal.id;
+    Ctx {
+        alias,
+        principal: principal.clone(),
+        subject: format!("principal:{principal}"),
+        tenant,
+        gate: BeliefGateService::new(probe.clone()),
+        repo: BeliefRepository::new(probe.clone()),
+        core: RecallCoreService::new(probe.clone()),
+        events: MemoryEventRepository::new(probe.clone()),
+        probe,
+        owner,
+    }
+}
+
+impl Ctx {
+    async fn evidence(&self, text: &str) -> String {
+        self.events
+            .append(
+                &self.tenant,
+                AppendMemoryEventRequest::new(self.principal.clone(), MemoryEventType::UserMessage)
+                    .payload(serde_json::json!({ "text": text }))
+                    .idempotency_key(format!("ev-{}-{text:0<10}", suffix())),
+            )
+            .await
+            .expect("evidence")
+            .id()
+            .to_string()
+    }
+
+    async fn commit(&self, predicate: &str, object: &str, source: BeliefSource) -> GateOutcome {
+        let out = self
+            .gate
+            .submit(
+                &self.tenant,
+                BeliefClaim::new(
+                    self.principal.clone(),
+                    self.subject.clone(),
+                    predicate,
+                    object,
+                    source,
+                )
+                .origin(ClaimOrigin::Api)
+                .idempotency_key(format!(
+                    "c|{}|{}|{}|{}",
+                    self.principal,
+                    predicate,
+                    object,
+                    suffix()
+                ))
+                .evidence(vec![self.evidence(&format!("{predicate} {object}")).await]),
+            )
+            .await
+            .expect("gate submit");
+        assert!(
+            matches!(
+                out,
+                GateOutcome::Committed { .. } | GateOutcome::Superseded { .. }
+            ),
+            "expected commit, got {out:?}"
+        );
+        out
+    }
+
+    fn service(&self, adapter: Arc<StaticSorAdapter>, batch: i64) -> BeliefConsolidationService {
+        BeliefConsolidationService::new(
+            self.probe.clone(),
+            adapter as Arc<dyn backend::services::consolidation::SorAdapter>,
+            BeliefConsolidationConfig {
+                per_tenant_batch: batch,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Count open (active|needs_confirm) edges for subject+predicate.
+    async fn open_count(&self, predicate: &str) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM memory_beliefs WHERE tenant_id=$1 AND subject=$2 AND predicate=$3 \
+             AND valid_to IS NULL AND status IN ('active','needs_confirm')",
+        )
+        .bind(self.tenant.as_str())
+        .bind(&self.subject)
+        .bind(predicate)
+        .fetch_one(&mut *backend::db::tenant_scope::begin_tenant_tx(&self.probe, &self.tenant).await.unwrap())
+        .await
+        .unwrap()
+    }
+}
+
+/// Run one tenant-scoped statement AND COMMIT it (a dropped Transaction rolls
+/// back — the exact trap this suite's first version fell into).
+async fn tx_exec(probe: &PgPool, tenant: &TenantId, sql: &str, binds: &[&str]) {
+    use backend::db::tenant_scope::begin_tenant_tx;
+    let mut tx = begin_tenant_tx(probe, tenant).await.expect("tx");
+    let mut q = sqlx::query(sql);
+    for b in binds {
+        q = q.bind(b);
+    }
+    q.execute(&mut *tx).await.expect("tx exec");
+    tx.commit().await.expect("tx commit");
+}
+
+fn no_adapter() -> Arc<StaticSorAdapter> {
+    Arc::new(StaticSorAdapter::new())
+}
+
+// ── Regression: multi-valued predicates coexist (#127 constraint fix) ────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn multi_valued_predicates_coexist() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("coex").await;
+    for obj in ["coffee", "tea", "dark-mode"] {
+        let _ = c.commit("prefers", obj, BeliefSource::UserStated).await;
+    }
+    assert_eq!(
+        c.open_count("prefers").await,
+        3,
+        "distinct preferences coexist"
+    );
+    // And a repeat of the SAME preference is a NOOP, not a new edge.
+    let dup = c
+        .gate
+        .submit(
+            &c.tenant,
+            BeliefClaim::new(
+                c.principal.clone(),
+                c.subject.clone(),
+                "prefers",
+                "coffee",
+                BeliefSource::UserStated,
+            )
+            .idempotency_key(format!("dup-{}", suffix()))
+            .evidence(vec![c.evidence("coffee again").await]),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(dup, GateOutcome::Noop { .. }), "{dup:?}");
+    assert_eq!(c.open_count("prefers").await, 3);
+}
+
+// ── 1. Multi-active detection + repair ───────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn multi_active_detected_and_repaired() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("multia").await;
+    let _ = c
+        .commit("works_at", "OldCo", BeliefSource::UserStated)
+        .await;
+
+    // Fabricate the anomaly the exclusion constraint should have prevented:
+    // drop it as the OWNER, insert a second open edge, restore afterwards.
+    sqlx::raw_sql(
+        "ALTER TABLE memory_beliefs DROP CONSTRAINT IF EXISTS beliefs_single_open_edge_per_subject",
+    )
+    .execute(&c.owner)
+    .await
+    .expect("drop constraint (idempotent)");
+    let anomalous_id = format!("anom-{}", suffix());
+    sqlx::query(
+        "INSERT INTO memory_beliefs (id, tenant_id, principal_id, subject, predicate, object, status, source, trust, risk, single_valued, last_confirmed_at) \
+         VALUES ($1,$2,$3,$4,'works_at','NewCoByBypass','active','user_stated',0.8,'medium',TRUE, NOW())",
+    )
+    .bind(&anomalous_id)
+    .bind(c.tenant.as_str())
+    .bind(&c.principal)
+    .bind(&c.subject)
+    .execute(&c.owner)
+    .await
+    .expect("fabricate anomaly");
+
+    let report = c.service(no_adapter(), 10).run_for_tenant(&c.tenant).await;
+    assert_eq!(
+        report.multi_active_repaired, 1,
+        "scan found the bypass group"
+    );
+    assert!(report.edges_closed_in_repair >= 1);
+    assert!(report.errors.is_empty(), "{:?}", report.errors);
+
+    // Exactly one open edge remains; the older one is closed and chain-linked.
+    assert_eq!(c.open_count("works_at").await, 1);
+    let winner = c
+        .repo
+        .open_edge(&c.tenant, &c.subject, "works_at")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(winner.object, "NewCoByBypass", "newest wins the slot");
+    let history = c
+        .repo
+        .history_for(&c.tenant, &c.subject, "works_at")
+        .await
+        .unwrap();
+    let loser = history.iter().find(|b| b.id != winner.id).unwrap();
+    assert_eq!(loser.status, "superseded");
+    assert!(loser.valid_to.is_some());
+    assert_eq!(loser.superseded_by_id.as_deref(), Some(winner.id.as_str()));
+
+    // The constraint can come back now that the invariant holds again.
+    sqlx::raw_sql(
+        "ALTER TABLE memory_beliefs ADD CONSTRAINT beliefs_single_open_edge_per_subject \
+         EXCLUDE USING gist (tenant_id WITH =, subject WITH =, predicate WITH =, \
+         tstzrange(valid_from, COALESCE(valid_to,'infinity'),'[)') WITH &&) \
+         WHERE (single_valued AND status IN ('active','needs_confirm'))",
+    )
+    .execute(&c.owner)
+    .await
+    .expect("constraint restored after repair");
+}
+
+// ── 2. Retired states leave default recall ───────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn retired_states_leave_recall() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("retire").await;
+
+    // (a) A promise with an explicit past due date retires to archived.
+    let _ = c
+        .gate
+        .submit(
+            &c.tenant,
+            BeliefClaim::new(
+                c.principal.clone(),
+                c.subject.clone(),
+                "promised",
+                "deliver by Friday",
+                BeliefSource::UserStated,
+            )
+            .payload(serde_json::json!({ "due_date": "2020-01-01T00:00:00Z" }))
+            .idempotency_key(format!("promise-{}", suffix()))
+            .evidence(vec![c.evidence("I promise").await]),
+        )
+        .await
+        .unwrap();
+
+    // (b) A mutable fact made stale-eligible by backdating last_confirmed_at.
+    let _ = c
+        .commit("works_at", "StaleCo", BeliefSource::UserStated)
+        .await;
+    tx_exec(
+        &c.probe,
+        &c.tenant,
+        "UPDATE memory_beliefs SET last_confirmed_at = NOW() - INTERVAL '400 days' WHERE tenant_id=$1 AND subject=$2 AND predicate='works_at'",
+        &[c.tenant.as_str(), &c.subject],
+    )
+    .await;
+
+    // Sanity: before consolidation both are recallable.
+    let before = c
+        .core
+        .recall(&c.tenant, &RecallQuery::new(&c.alias, ""))
+        .await
+        .unwrap();
+    assert!(before.items.iter().any(|i| i.predicate == "promised"));
+    assert!(before.items.iter().any(|i| i.object == "StaleCo"));
+
+    let report = c.service(no_adapter(), 10).run_for_tenant(&c.tenant).await;
+    assert_eq!(report.promises_expired, 1);
+    assert!(report.stale_marked + report.confirm_queued >= 1);
+
+    let after = c
+        .core
+        .recall(&c.tenant, &RecallQuery::new(&c.alias, ""))
+        .await
+        .unwrap();
+    assert!(
+        !after.items.iter().any(|i| i.predicate == "promised"),
+        "expired promise left the current set"
+    );
+    assert!(
+        !after.items.iter().any(|i| i.object == "StaleCo"),
+        "stale fact left the current set"
+    );
+    // History preserved: both still exist as rows, just not current truth.
+    let promise_hist = c
+        .repo
+        .history_for(&c.tenant, &c.subject, "promised")
+        .await
+        .unwrap();
+    assert_eq!(promise_hist.len(), 1);
+    assert_eq!(promise_hist[0].status, "archived");
+    assert!(promise_hist[0].valid_to.is_some());
+}
+
+// ── 3. SoR close/reconfirm within one cycle ──────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn sor_change_closes_and_reconfirms() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("sor").await;
+    let _ = c
+        .commit("works_at", "OldCo", BeliefSource::UserStated)
+        .await;
+
+    // HR says transferred.
+    let adapter = Arc::new(StaticSorAdapter::new());
+    adapter.set_updates(
+        &c.tenant,
+        vec![SorUpdate::new(&c.subject, "works_at", "NewCo", "hr-mock").principal(&c.principal)],
+    );
+    let report = c
+        .service(adapter.clone(), 10)
+        .run_for_tenant(&c.tenant)
+        .await;
+    assert_eq!(
+        report.sor_closed, 1,
+        "SoR supersedes within one cycle (the SLA)"
+    );
+    assert_eq!(report.sor_diffs, 1);
+
+    let open = c
+        .repo
+        .open_edge(&c.tenant, &c.subject, "works_at")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(open.object, "NewCo");
+    assert_eq!(open.source, "system_of_record");
+    // Old edge closed with chain pointer — history intact.
+    let history = c
+        .repo
+        .history_for(&c.tenant, &c.subject, "works_at")
+        .await
+        .unwrap();
+    let old = history.iter().find(|b| b.object == "OldCo").unwrap();
+    assert_eq!(old.status, "superseded");
+
+    // HR re-vouches the SAME value: reconfirm refreshes the clock; a stale
+    // edge returns to active without a new version.
+    tx_exec(
+        &c.probe,
+        &c.tenant,
+        "UPDATE memory_beliefs SET last_confirmed_at = NOW() - INTERVAL '400 days', status='stale' WHERE tenant_id=$1 AND subject=$2 AND predicate='works_at' AND valid_to IS NULL",
+        &[c.tenant.as_str(), &c.subject],
+    )
+    .await;
+    adapter.set_updates(
+        &c.tenant,
+        vec![SorUpdate::new(&c.subject, "works_at", "NewCo", "hr-mock").principal(&c.principal)],
+    );
+    let report2 = c.service(adapter, 10).run_for_tenant(&c.tenant).await;
+    assert_eq!(
+        report2.sor_refreshed, 1,
+        "same-object SoR update reconfirms"
+    );
+    let revived = c
+        .repo
+        .open_edge(&c.tenant, &c.subject, "works_at")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(revived.status, "active", "stale edge revived by authority");
+    assert_eq!(
+        c.repo
+            .history_for(&c.tenant, &c.subject, "works_at")
+            .await
+            .unwrap()
+            .len(),
+        2,
+        "no extra version rows"
+    );
+}
+
+// ── 4. Idempotent double run ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn double_run_is_idempotent() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("idem").await;
+    let _ = c
+        .commit("works_at", "OldCo", BeliefSource::UserStated)
+        .await;
+    tx_exec(
+        &c.probe,
+        &c.tenant,
+        "UPDATE memory_beliefs SET last_confirmed_at = NOW() - INTERVAL '400 days' WHERE tenant_id=$1 AND subject=$2 AND predicate='works_at'",
+        &[c.tenant.as_str(), &c.subject],
+    )
+    .await;
+
+    let adapter = no_adapter();
+    let svc = c.service(adapter, 10);
+    let r1 = svc.run_for_tenant(&c.tenant).await;
+    async fn snapshot(ctx: &Ctx) -> (Vec<(String, String, Option<String>)>, usize) {
+        let hist = ctx
+            .repo
+            .history_for(&ctx.tenant, &ctx.subject, "works_at")
+            .await
+            .unwrap();
+        let candidates = ctx
+            .repo
+            .list_candidates(&ctx.tenant, None, 100)
+            .await
+            .unwrap()
+            .len();
+        (
+            hist.iter()
+                .map(|b| (b.id.clone(), b.status.clone(), b.valid_to.clone()))
+                .collect(),
+            candidates,
+        )
+    }
+    let s1 = snapshot(&c).await;
+    let r2 = svc.run_for_tenant(&c.tenant).await;
+    let s2 = snapshot(&c).await;
+
+    assert_eq!(
+        s1, s2,
+        "identical belief state and candidate count after the second run"
+    );
+    assert_eq!(
+        r2.stale_marked + r2.confirm_queued,
+        0,
+        "nothing left to mark"
+    );
+    assert!(r2.errors.is_empty(), "{:?}", r2.errors);
+    assert!(r1.stale_marked + r1.confirm_queued >= 1);
+}
+
+// ── 5. Tenant fairness ───────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn tenant_fair_batching() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let (owner, probe) = pools();
+    let big = ctx("fairbig").await;
+    let small = ctx("fairsmall").await;
+
+    // Big tenant: 12 stale-eligible mutable facts. Small tenant: 1.
+    for ctx in [&big, &small] {
+        let n = if std::ptr::eq(ctx.tenant.as_str(), big.tenant.as_str()) {
+            12
+        } else {
+            1
+        };
+        for i in 0..n {
+            let pred = if i == 0 { "works_at" } else { "prefers" };
+            let _ = ctx
+                .gate
+                .submit(
+                    &ctx.tenant,
+                    BeliefClaim::new(
+                        ctx.principal.clone(),
+                        ctx.subject.clone(),
+                        pred,
+                        if pred == "works_at" {
+                            "AgedCo".to_string()
+                        } else {
+                            format!("old-pref-{i}")
+                        },
+                        BeliefSource::UserStated,
+                    )
+                    .idempotency_key(format!("fair|{}|{i}", ctx.principal))
+                    .evidence(vec![ctx.evidence(&format!("fair {i}")).await]),
+                )
+                .await
+                .unwrap();
+        }
+        tx_exec(
+            &probe,
+            &ctx.tenant,
+            "UPDATE memory_beliefs SET last_confirmed_at = NOW() - INTERVAL '400 days' WHERE tenant_id=$1 AND subject=$2",
+            &[ctx.tenant.as_str(), &ctx.subject],
+        )
+        .await;
+    }
+    let _ = (&owner, &small.alias);
+
+    // Budget of 5 per scan per tenant: the big tenant processes part of its
+    // backlog while the small tenant finishes ENTIRELY in the same round.
+    let svc = BeliefConsolidationService::new(
+        probe.clone(),
+        no_adapter() as Arc<dyn backend::services::consolidation::SorAdapter>,
+        BeliefConsolidationConfig {
+            per_tenant_batch: 5,
+            ..Default::default()
+        },
+    );
+    let reports = svc
+        .process_round(&[big.tenant.clone(), small.tenant.clone()])
+        .await;
+    let big_report = &reports[big.tenant.as_str()];
+    let small_report = &reports[small.tenant.as_str()];
+    assert_eq!(
+        big_report.stale_marked + big_report.confirm_queued,
+        5,
+        "big tenant got exactly its budget"
+    );
+    assert_eq!(
+        small_report.stale_marked + small_report.confirm_queued,
+        1,
+        "small tenant was NOT starved by the big backlog"
+    );
+}
+
+// ── 6. Crash-restart: no duplicate supersede ─────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn crash_restart_no_duplicate_supersede() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("crash").await;
+    let _ = c
+        .commit("works_at", "OldCo", BeliefSource::UserStated)
+        .await;
+
+    // Same SoR update applied across THREE separate "process lifetimes"
+    // (fresh service instances, as after a crash-restart). Exactly one
+    // supersede happens; the replays resolve to the original outcome.
+    for _ in 0..3 {
+        let adapter = Arc::new(StaticSorAdapter::new());
+        adapter.set_updates(
+            &c.tenant,
+            vec![
+                SorUpdate::new(&c.subject, "works_at", "NewCo", "crm-mock").principal(&c.principal)
+            ],
+        );
+        let svc = BeliefConsolidationService::new(
+            c.probe.clone(),
+            adapter as Arc<dyn backend::services::consolidation::SorAdapter>,
+            Default::default(),
+        );
+        let _ = svc.run_for_tenant(&c.tenant).await;
+    }
+
+    let history = c
+        .repo
+        .history_for(&c.tenant, &c.subject, "works_at")
+        .await
+        .unwrap();
+    assert_eq!(
+        history.len(),
+        2,
+        "two versions only — no duplicate supersede links"
+    );
+    assert_eq!(
+        history.iter().filter(|b| b.status == "superseded").count(),
+        1
+    );
+    assert_eq!(history.iter().filter(|b| b.status == "active").count(), 1);
+    // Idempotency-keyed candidates: one reconcile trail, not three.
+    let sor_candidates = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM memory_belief_candidates WHERE tenant_id=$1 AND idempotency_key LIKE 'sor|crm-mock|%'",
+    )
+    .bind(c.tenant.as_str())
+    .fetch_one(&mut *backend::db::tenant_scope::begin_tenant_tx(&c.probe, &c.tenant).await.unwrap())
+    .await
+    .unwrap();
+    assert_eq!(
+        sor_candidates, 1,
+        "claim-level idempotency collapses replays"
+    );
+}
+
+// ── 7. Metrics advance on real runs ──────────────────────────────────────────
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn metrics_advance_on_real_runs() {
+    if std::env::var("DATABASE_URL").is_err() {
+        eprintln!("SKIP");
+        return;
+    }
+    let c = ctx("metric").await;
+    let _ = c
+        .commit("works_at", "OldCo", BeliefSource::UserStated)
+        .await;
+    tx_exec(
+        &c.probe,
+        &c.tenant,
+        "UPDATE memory_beliefs SET last_confirmed_at = NOW() - INTERVAL '400 days' WHERE tenant_id=$1 AND subject=$2 AND predicate='works_at'",
+        &[c.tenant.as_str(), &c.subject],
+    )
+    .await;
+
+    let adapter = Arc::new(StaticSorAdapter::new());
+    adapter.set_updates(
+        &c.tenant,
+        vec![
+            SorUpdate::new(&c.subject, "works_at", "MetricCo", "crm-mock").principal(&c.principal),
+        ],
+    );
+
+    let before = metric_snapshot();
+    let report = c.service(adapter, 10).run_for_tenant(&c.tenant).await;
+    let after = metric_snapshot();
+
+    // Counters are process-global and this suite runs its tests in parallel:
+    // assert MONOTONE growth of at least this run's contribution.
+    assert!(
+        after.runs >= before.runs + 1,
+        "runs advanced: {} -> {}",
+        before.runs,
+        after.runs
+    );
+    assert!(after.stale >= before.stale + (report.stale_marked + report.confirm_queued) as u64);
+    assert!(after.reconciliation_diffs >= before.reconciliation_diffs + report.sor_diffs as u64);
+    assert!(
+        after.run_duration_observed >= before.run_duration_observed + 1,
+        "latency histogram observed: {} -> {}",
+        before.run_duration_observed,
+        after.run_duration_observed
+    );
+    assert!(report.errors.is_empty(), "{:?}", report.errors);
+}
+
+#[derive(Default)]
+struct MetricSnapshot {
+    runs: u64,
+    stale: u64,
+    reconciliation_diffs: u64,
+    failures: u64,
+    run_duration_observed: u64,
+}
+
+fn metric_snapshot() -> MetricSnapshot {
+    // Real-caller surface: the /metrics exposition the exporter serves. Reading
+    // through gather() proves the counters are REGISTERED and moved by the
+    // service, not just incremented in isolation.
+    use prometheus::Encoder as _;
+    let exporter = backend::services::prometheus_exporter::get_exporter();
+    let text = exporter.generate_prometheus_output();
+
+    let pick = |name: &str| -> u64 {
+        for line in text.lines() {
+            let with_underscore = format!("{name}_");
+            if line.starts_with(name) && !line.starts_with(&with_underscore) {
+                if let Some(v) = line.rsplit(' ').next() {
+                    if let Ok(f) = v.parse::<f64>() {
+                        return f as u64;
+                    }
+                }
+            }
+        }
+        0
+    };
+    let observed = text
+        .lines()
+        .find(|l| l.starts_with("consolidation_run_duration_seconds_count"))
+        .and_then(|l| l.rsplit(' ').next())
+        .and_then(|v| v.parse::<f64>().ok())
+        .map(|f| f as u64)
+        .unwrap_or(0);
+    MetricSnapshot {
+        runs: pick("consolidation_runs_total"),
+        stale: pick("consolidation_stale_marked_total"),
+        reconciliation_diffs: pick("consolidation_reconciliation_diffs_total"),
+        failures: pick("consolidation_failures_total"),
+        run_duration_observed: observed,
+    }
+}


### PR DESCRIPTION
## 概要

Epic #124 第五子项（**PR-5/6**，依赖 #127/#128 已合并）。交付可运行、可观测、幂等的离线巩固闭环；并修复一个 #127 遗留的真实约束缺陷。

Closes #129 · Refs #124

## 首要修复：#127 排他约束未区分基数

本 issue 的"多 active 单值谓词"扫描直接暴露了它：**排他约束对所有谓词生效，多值谓词（prefers/owner_of/member_of…）永远只能持一条开边**——门卫用同级 supersede 掩盖，悄悄摧毁了 #125 目录定义的多值语义（15 条偏好只剩 1 条存活，其余被无声取代）。

修复（迁移 `20260901000001`）：
- `single_valued` 反规范化列（EXCLUDE 无法 JOIN 政策表），约束重建为 `WHERE (single_valued AND status IN (...))`，**只约束单值谓词**；
- 门卫按基数分流：多值谓词按 object 匹配比较——不同 object 共存、相同 object NOOP；
- 回归测试 `multi_valued_predicates_coexist` 锁定该语义。

## 巩固闭环（`services/consolidation.rs` + worker）

| 扫描 | 行为 |
|---|---|
| 多 active（防御纵深） | 保留最新开边、闭合其余（链指针）；更强来源落败 → winner 进 needs_confirm |
| stale | 超 `reconfirm_days` 窗口且非 SoR 来源 → `stale`；**高反馈量（≥2）进人工待确认队列** |
| 承诺到期 | `due_date` 元数据优先 / `valid_from+90d` 兜底 → 闭合 + `archived`（保留为 history） |
| 网页衰减 | 48h/96h **固定信任平台**（幂等），低于动作阈值 |
| SoR 对账 | `SorAdapter` trait + `StaticSorAdapter`（最小 CRM/HR 模拟）；`reconcile_target` 含 stale 边：同值**再确认**（复活 stale、零新版本）、异值经**写入门卫** supersede——弱于门卫者从不直接写库 |

所有修正走 supersede/close，绝不原地改历史；`last_confirmed_at` 新列让 SoR 再确认重置老化时钟而不改写 valid 窗口。

**租户公平**：每扫描每租户 batch 上限（默认 100）。**幂等/崩溃安全**：guarded UPDATE + claim 级幂等键（`consolidation|action|belief_id`、`sor|system|s|p|o`）。**worker**：config 门控（默认开、3600s），main 非关键启动。

## 指标（exporter 注册，测试经 /metrics 全注册表验证真实调用）

`consolidation_run_duration_seconds`（直方图）、`runs/conflicts/stale_marked/promises_expired/reconciliation_diffs/failures_total`。

## 验收标准对照（7/7 + 回归，8/8 测试）

| #129 验收 | 证据 |
|---|---|
| 1. 多 active 检测→conflict/confirm | owner 池摘约束伪造异常（真实约束下不可能）→ 修复扫描闭合多余边、恢复约束可加回 |
| 2. stale/expired/archived 不进当前召回 | 巩固后 recall 断言缺席；archived 行保留历史窗口 |
| 3. SoR 变更 SLA 内闭合 | 一个周期内 supersede（diffs/sor_closed 断言）；同值再确认复活 stale 零新版本 |
| 4. 双跑幂等 | 状态快照（边状态+窗口+候选数）两次运行完全一致 |
| 5. 租户公平 | 大租户 12 项 × batch=5 → 恰好处理 5；小租户 1 项同轮全部完成 |
| 6. 崩溃重启无重复 supersede | 三次"进程重启"同一 SoR 更新 → 恰好 2 版本、1 条 supersede、1 条幂等候选 |
| 7. 指标有真实调用者 | /metrics 全注册表输出前后快照，计数器按本 run 贡献单调增长 |

## 验证证据

| 项 | 结果 |
|---|---|
| `cargo test --lib` | ✅ 504 passed / 0 failed |
| 全量集成回归（PG 容器 + `--include-ignored`） | ✅ **1213 passed / 0 failed**（含 #127/#128 套件在约束变更后全绿） |
| `consolidation_pg` 稳定性 | ✅ 连续 3 次 8/8（~0.77s/次） |
| rustfmt（触及文件） | ✅ 干净 |

调试修掉的真实问题：JOIN 扫描 `risk` 列歧义（`BELIEF_COLS_B`）；测试里临时事务 drop 即回滚的陷阱；PG 无 `ADD CONSTRAINT IF NOT EXISTS`（DO 块）；全局计数器并行下的断言改单调增长。

## 后续

#130（治理 API、可观测性与黄金验收测试）——Epic 最后一个子项。